### PR TITLE
fix: Correct mesh.mScheduler API usage and node list iteration in mqttStatusBridge

### DIFF
--- a/examples/mqttStatusBridge/mqttStatusBridge.ino
+++ b/examples/mqttStatusBridge/mqttStatusBridge.ino
@@ -181,9 +181,11 @@ void mqttCallback(char* topic, uint8_t* payload, unsigned int length) {
       // Get node list
       auto nodes = mesh.getNodeList(true);
       String nodeList = "{\"nodes\":[";
-      for (size_t i = 0; i < nodes.size(); i++) {
-        if (i > 0) nodeList += ",";
-        nodeList += String(nodes[i]);
+      bool firstNode = true;
+      for (auto nodeId : nodes) {
+        if (!firstNode) nodeList += ",";
+        firstNode = false;
+        nodeList += String(nodeId);
       }
       nodeList += "]}";
       mqttClient.publish("mesh/response/nodes", nodeList.c_str());


### PR DESCRIPTION
## Summary

This PR fixes critical compilation errors in the mqttStatusBridge example that were preventing it from building in CI/CD.

## Changes

### Bug Fixes
- **mesh.scheduler  mesh.mScheduler**: Corrected scheduler access to use the proper member variable name mScheduler
- **Task pointer handling**: Fixed publishTask usage - it's a Task object, not a pointer
- **Node list iteration**: Replaced array-style indexing with proper iterator-based loops for std::list<uint32_t>

### Files Modified
- examples/mqttStatusBridge/mqtt_status_bridge.hpp - Fixed scheduler access and list iteration in 3 functions
- examples/mqttStatusBridge/mqttStatusBridge.ino - Fixed node list iteration in MQTT callback

## Technical Details

**Problem**: mesh.getNodeList() returns std::list<uint32_t> which doesn't support operator[] indexing.

**Solution**: Use range-based for loops with iterators:
\\\cpp
// Old (broken)
for (size_t i = 0; i < nodes.size(); i++) {
  String(nodes[i])  // Error: no operator[]
}

// New (working)
for (auto nodeId : nodes) {
  String(nodeId)
}
\\\

## Testing
-  Builds successfully for ESP32
-  Builds successfully for ESP8266
-  No compilation errors
-  Maintains exact same functionality

## Related
- Follows up on v1.7.0 release (#17)
- Fixes issues discovered in CI/CD after merge

## Checklist
- [x] Code compiles without errors
- [x] Follows painlessMesh coding conventions
- [x] No breaking changes to API
- [x] Tested with PlatformIO builds