### PR TITLE
Potential fix for code scanning alert no. 1: Use of potentially dangerous function

### DIFF
--- a/test/include/catch2/catch.hpp
+++ b/test/include/catch2/catch.hpp
@@ -16818,8 +16818,8 @@ namespace Catch {
             std::tm timeInfo = {};
             gmtime_s(&timeInfo, &rawtime);
 #else
-            std::tm* timeInfo;
-            timeInfo = std::gmtime(&rawtime);
+            std::tm timeInfoStorage;
+            std::tm* timeInfo = gmtime_r(&rawtime, &timeInfoStorage);
 #endif
 
             char timeStamp[timeStampSize];


### PR DESCRIPTION
Potential fix for [https://github.com/Alteriom/painlessMesh/security/code-scanning/1](https://github.com/Alteriom/painlessMesh/security/code-scanning/1)

To fix the problem, we should use the thread-safe variant `gmtime_r` instead of `gmtime` for non-MSVC builds. This requires:  
- Allocating a local `std::tm` struct.
- Passing both `rawtime` and the local `std::tm` to `gmtime_r`, which returns a pointer to the local struct (or NULL on error).
- Passing the address of this struct to `strftime`.

Specifically, in `getCurrentTimestamp`:
- Replace the lines:
  ```cpp
  std::tm* timeInfo;
  timeInfo = std::gmtime(&rawtime);
  ```
  with:
  ```cpp
  std::tm timeInfoStorage;
  std::tm* timeInfo = gmtime_r(&rawtime, &timeInfoStorage);
  ```
- Replace any downstream uses accordingly.
- Ensure `<ctime>` is included (it already is).
- No other code region requires changing.
- No external dependencies or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
