### PR TITLE
Potential fix for code scanning alert no. 2: Potentially overrunning write with float to string conversion

### DIFF
--- a/test/include/catch2/catch.hpp
+++ b/test/include/catch2/catch.hpp
@@ -15784,9 +15784,9 @@ namespace Catch {
         // Save previous errno, to prevent sprintf from overwriting it
         ErrnoGuard guard;
 #ifdef _MSC_VER
-        sprintf_s(buffer, "%.3f", duration);
+        _snprintf_s(buffer, maxDoubleSize, _TRUNCATE, "%.3f", duration);
 #else
-        std::sprintf(buffer, "%.3f", duration);
+        std::snprintf(buffer, maxDoubleSize, "%.3f", duration);
 #endif
         return std::string(buffer);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Alteriom/painlessMesh/security/code-scanning/2](https://github.com/Alteriom/painlessMesh/security/code-scanning/2)

To fix this problem, we should replace the use of `sprintf`/`sprintf_s` with their safer equivalents, `snprintf` (or `_snprintf_s` on MSVC where available), which require the user to specify the length of the output buffer. This change ensures that even in the most pathological case, writing to the buffer will not overflow its bounds. 

**Detailed fix:**
- Replace the call to `sprintf_s(buffer, "%.3f", duration);` with `snprintf(buffer, maxDoubleSize, "%.3f", duration);` (on MSVC, `_snprintf_s(buffer, maxDoubleSize, _TRUNCATE, "%.3f", duration);` would be even safer).
- Similarly, replace `std::sprintf(buffer, "%.3f", duration);` with `std::snprintf(buffer, maxDoubleSize, "%.3f", duration);` on non-MSVC platforms.
- Ensure the proper header `<cstdio>` is included (already present).
- No change to the buffer size logic, as this is reasonably accurate.
- These changes should be done only in the function `getFormattedDuration`, lines 15786–15790.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
