### PR TITLE
Potential fix for code scanning alert no. 3: Wrong type of arguments to formatting function

### DIFF
--- a/src/painlessmesh/message_queue.hpp
+++ b/src/painlessmesh/message_queue.hpp
@@ -143,7 +143,7 @@ public:
     // Check for state change
     checkStateChange();
     
-    Log(logger::GENERAL, "MessageQueue: Enqueued message #%u (priority=%d, size=%u/%u)\n",
+    Log(logger::GENERAL, "MessageQueue: Enqueued message #%u (priority=%d, size=%zu/%zu)\n",
         msgId, priority, messages.size(), maxQueueSize);
     
     return msgId;
@@ -167,7 +167,7 @@ public:
       updatePriorityStats();
       checkStateChange();
       
-      Log(logger::GENERAL, "MessageQueue: Removed message #%u (size=%u)\n",
+      Log(logger::GENERAL, "MessageQueue: Removed message #%u (size=%zu)\n",
           messageId, messages.size());
       return true;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Alteriom/painlessMesh/security/code-scanning/3](https://github.com/Alteriom/painlessMesh/security/code-scanning/3)

**General Fix:**  
The format specifier in the `Log` call must match the type of the arguments. Since `messages.size()` and `maxQueueSize` are likely of type `size_t`, `%zu` should be used as the format specifier to properly print these values.

**Detailed Fix:**  
- In `src/painlessmesh/message_queue.hpp`, line 146-147, update the format string in the `Log` call within the `enqueue` method to use `%zu` for both `messages.size()` and `maxQueueSize`.
- Also, similarly update the other `Log` call within the `remove` method, line 170-171, from `%u` to `%zu` for `messages.size()`.

**Requirements:**  
- No new imports or dependencies are necessary since this is standard `printf` format string usage.
- No other changes beyond adjusting the format string are required within the provided context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
