### PR TITLE
Potential fix for code scanning alert no. 5: Wrong type of arguments to formatting function

### DIFF
--- a/src/painlessmesh/message_queue.hpp
+++ b/src/painlessmesh/message_queue.hpp
@@ -144,7 +144,7 @@ public:
     checkStateChange();
     
     Log(logger::GENERAL, "MessageQueue: Enqueued message #%u (priority=%d, size=%zu/%zu)\n",
-        msgId, priority, messages.size(), maxQueueSize);
+        msgId, priority, messages.size(), (size_t)maxQueueSize);
     
     return msgId;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Alteriom/painlessMesh/security/code-scanning/5](https://github.com/Alteriom/painlessMesh/security/code-scanning/5)

To fix the problem, adjust either the format specifier or the argument type so they match: either change `%zu` to `%u` if `maxQueueSize` is `unsigned int`, or cast/convert `maxQueueSize` to `size_t` so that `%zu` is appropriate, or ideally change the definition of `maxQueueSize` to be `size_t` if it is used with size-related operations. However, since we are to avoid changing definitions unless shown, the best fix is to cast `maxQueueSize` to `size_t` in the log statement, matching the `%zu` specifier as used for `messages.size()`. This keeps formatting consistent and logs without risk.

Change needed: In file `src/painlessmesh/message_queue.hpp`, in the log statement at line 146-147, update the fourth argument from `maxQueueSize` to `(size_t)maxQueueSize` so its type matches `%zu`.

No new methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
