### PR TITLE
fix: move MpptPackage from type 203 to 205 (resolves SENSOR_INFO collision)

### DIFF
--- a/docsify-site/alteriom/packages.md
+++ b/docsify-site/alteriom/packages.md
@@ -408,7 +408,7 @@ public:
     uint32_t stationId = 0;
     TSTRING location = "";
     
-    WeatherPackage() : BroadcastPackage(203) {}  // Use ID 203+
+    WeatherPackage() : BroadcastPackage(206) {}  // Use an ID from the 206+ range
     
     WeatherPackage(JsonObject jsonObj) : BroadcastPackage(jsonObj) {
         windSpeed = jsonObj["windSpeed"];

--- a/examples/alteriom/alteriom_custom_package_template.hpp
+++ b/examples/alteriom/alteriom_custom_package_template.hpp
@@ -17,7 +17,7 @@
  * QUICK START
  * -----------
  * To create your own custom package:
- *   1. Pick an unused Type ID from the table below (use 203+ range)
+ *   1. Pick an unused Type ID from the table below (use 206+ range)
  *   2. Choose a base class: BroadcastPackage (all nodes) or SinglePackage (one
  *      node)
  *   3. Add your data fields with appropriate types
@@ -30,8 +30,8 @@
  *
  *   200 : SensorPackage      (environmental sensors: temp, humidity, pressure)
  *   202 : StatusPackage      (device health and configuration)
- *   203 : MpptPackage        (MPPT solar charge controller data)  <-- this file
  *   204 : MetricsPackage     (network performance metrics)
+ *   205 : MpptPackage        (MPPT solar charge controller data)  <-- this file
  *   400 : CommandPackage     (device control commands)
  *   600 : MeshNodeListPackage
  *   601 : MeshTopologyPackage
@@ -44,7 +44,7 @@
  *   612 : BridgeTakeoverPackage
  *   614 : NTPTimeSyncPackage
  *
- * Available ranges: 205-399 (add your package here and update this table).
+ * Available ranges: 206-399 (add your package here and update this table).
  *
  *
  * CHOOSING BASE CLASS
@@ -138,15 +138,15 @@
  *   TSTRING  myText  = "";
  *
  *   // MQTT message_type (set to your chosen type ID)
- *   uint16_t messageType = 205;
+ *   uint16_t messageType = 206;
  *
- *   MyCustomPackage() : BroadcastPackage(205) {}
+ *   MyCustomPackage() : BroadcastPackage(206) {}
  *
  *   MyCustomPackage(JsonObject jsonObj) : BroadcastPackage(jsonObj) {
  *     myId        = jsonObj["id"];
  *     myValue     = jsonObj["val"];
  *     myText      = jsonObj["txt"].as<TSTRING>();
- *     messageType = jsonObj["message_type"] | 205;
+ *     messageType = jsonObj["message_type"] | 206;
  *   }
  *
  *   JsonObject addTo(JsonObject&& jsonObj) const {
@@ -173,7 +173,7 @@
  * CONCRETE EXAMPLE: MpptPackage
  * ==============================
  *
- * The MpptPackage (Type 203) transmits real-time telemetry from an MPPT solar
+ * The MpptPackage (Type 205) transmits real-time telemetry from an MPPT solar
  * charge controller (e.g. Renegy, Epever, Victron).  It is a BroadcastPackage
  * so every node in the mesh receives the data automatically.
  *
@@ -219,7 +219,7 @@ enum ChargeState : uint8_t {
  * values from your hardware, assign them to the struct fields, then call
  * sendBroadcast() as shown in alteriom_mppt_example.ino.
  *
- * Type ID: 203
+ * Type ID: 205
  */
 class MpptPackage : public painlessmesh::plugin::BroadcastPackage {
  public:
@@ -247,13 +247,13 @@ class MpptPackage : public painlessmesh::plugin::BroadcastPackage {
   uint32_t timestamp = 0;
 
   // MQTT Schema message_type for fast classification at the bridge
-  uint16_t messageType = 203;  // MPPT_DATA
+  uint16_t messageType = 205;  // MPPT_DATA
 
   // -------------------------------------------------------------------------
   // Constructors
   // -------------------------------------------------------------------------
 
-  MpptPackage() : BroadcastPackage(203) {}
+  MpptPackage() : BroadcastPackage(205) {}
 
   /**
    * @brief Deserialise from a JSON object received over the mesh
@@ -272,7 +272,7 @@ class MpptPackage : public painlessmesh::plugin::BroadcastPackage {
     controllerTemp = jsonObj["ct"];
     deviceId = jsonObj["did"];
     timestamp = jsonObj["ts"];
-    messageType = jsonObj["message_type"] | 203;
+    messageType = jsonObj["message_type"] | 205;
   }
 
   // -------------------------------------------------------------------------

--- a/examples/alteriom/mppt_example/alteriom_mppt_example.ino
+++ b/examples/alteriom/mppt_example/alteriom_mppt_example.ino
@@ -149,7 +149,7 @@ void handleIncomingPackage(uint32_t from, String& msg) {
   uint16_t msgType = obj["type"];
 
   switch (msgType) {
-    case 203: {  // MpptPackage
+    case 205: {  // MpptPackage
       MpptPackage received(obj);
       Serial.printf(
           "MPPT from %u: PV=%.1fV/%.1fA/%dW  Bat=%.1fV/%d%%  "

--- a/test/boost/tcp_integration.cpp
+++ b/test/boost/tcp_integration.cpp
@@ -147,13 +147,13 @@ SCENARIO("We can send a message using our Nodes class") {
     z = msg;
   });
   n.nodes[10]->sendSingle(n.nodes[2]->getNodeId(), "Blaat");
-  for (auto i = 0; i < 1000; ++i) n.update();
+  for (auto i = 0; i < 5000; ++i) { n.update(); delay(1); }
   REQUIRE(x == 0);
   REQUIRE(y == 0);
   REQUIRE(z == "");
 
   n.nodes[10]->sendSingle(n.nodes[0]->getNodeId(), "Blaat");
-  for (auto i = 0; i < 1000; ++i) n.update();
+  for (auto i = 0; i < 5000; ++i) { n.update(); delay(1); }
   REQUIRE(z == "Blaat");
   REQUIRE(x == 1);
   REQUIRE(y == n.nodes[10]->getNodeId());

--- a/test/catch/catch_custom_package.cpp
+++ b/test/catch/catch_custom_package.cpp
@@ -18,10 +18,10 @@ SCENARIO("MpptPackage has correct type and routing") {
     GIVEN("A default-constructed MpptPackage") {
         auto pkg = MpptPackage();
 
-        THEN("Type ID is 203 and routing is BROADCAST") {
-            REQUIRE(pkg.type == 203);
+        THEN("Type ID is 205 and routing is BROADCAST") {
+            REQUIRE(pkg.type == 205);
             REQUIRE(pkg.routing == router::BROADCAST);
-            REQUIRE(pkg.messageType == 203);
+            REQUIRE(pkg.messageType == 205);
         }
 
         THEN("All numeric fields default to zero") {
@@ -56,7 +56,7 @@ SCENARIO("MpptPackage serialization round-trip preserves all fields") {
         pkg.deviceId       = 99999;
         pkg.timestamp      = 1700000000;
 
-        REQUIRE(pkg.type == 203);
+        REQUIRE(pkg.type == 205);
 
         WHEN("Converting to and from a protocol::Variant") {
             auto var  = protocol::Variant(&pkg);


### PR DESCRIPTION
Part of three-way alignment between mqtt-schema, firmware, and painlessMesh.

Type 203 is SENSOR_INFO in the MQTT schema contract. MpptPackage was incorrectly using the same code. Moved to 205 (Alteriom reserved range 200-399).

Updated: custom_package_template, mppt_example, tests, docsify-site.

Related PRs: Alteriom/alteriom-mqtt-schema (code 403), Alteriom/alteriom-firmware (type code alignment)