### PR TITLE
fix: resolve use-after-free issue in Task::disable() with safe AsyncC…

### DIFF
--- a/src/arduino/wifi.hpp
+++ b/src/arduino/wifi.hpp
@@ -1964,12 +1964,21 @@ class Mesh : public painlessmesh::Mesh<Connection> {
 
     // Save current mesh configuration to restore if bridge init fails
     uint8_t savedChannel = _meshChannel;
+    TSTRING savedMeshSSID = _meshSSID;
+    TSTRING savedMeshPassword = _meshPassword;
+    TSTRING savedRouterSSID = routerSSID;
+    TSTRING savedRouterPassword = routerPassword;
+    Scheduler *savedScheduler = mScheduler;
+    auto savedBridgeRoleChangedCallback = bridgeRoleChangedCallback;
 
     // CRITICAL FIX: Schedule the stop/reinit work to run after current task completes
     // This prevents use-after-free crash when stop() clears taskList while
     // evaluateElection() task is still executing
     // Use minimal delay to allow current task to complete first
-    this->addTask(ASYNC_PROMOTION_DELAY_MS, TASK_ONCE, [this, savedChannel]() {
+    this->addTask(ASYNC_PROMOTION_DELAY_MS, TASK_ONCE,
+                  [this, savedChannel, savedMeshSSID, savedMeshPassword,
+                   savedRouterSSID, savedRouterPassword, savedScheduler,
+                   savedBridgeRoleChangedCallback]() {
       using namespace logger;
       
       Log(STARTUP, "Executing bridge promotion (stop/reinit cycle)\n");
@@ -1981,18 +1990,17 @@ class Mesh : public painlessmesh::Mesh<Connection> {
 
       // initAsBridge always returns true: bridge mesh functionality is active
       // regardless of router connection status (router connection is opportunistic)
-      this->initAsBridge(_meshSSID, _meshPassword, routerSSID, routerPassword,
-                         mScheduler, _meshPort);
+      this->initAsBridge(savedMeshSSID, savedMeshPassword, savedRouterSSID,
+                         savedRouterPassword, savedScheduler, _meshPort);
 
       lastRoleChangeTime = millis();
 
       Log(STARTUP, "[OK] Bridge promotion complete on channel %d\n", _meshChannel);
 
       // Notify via callback
-      // Use explicit TSTRING construction to ensure string lifetime safety
-      if (bridgeRoleChangedCallback) {
+      if (savedBridgeRoleChangedCallback) {
         static const TSTRING reason = "Election winner - best router signal";
-        bridgeRoleChangedCallback(true, reason);
+        savedBridgeRoleChangedCallback(true, reason);
       }
 
       // Note: The initial takeover announcement was already sent earlier
@@ -2067,12 +2075,21 @@ class Mesh : public painlessmesh::Mesh<Connection> {
 
     // Save current mesh configuration
     uint8_t savedChannel = _meshChannel;
+    TSTRING savedMeshSSID = _meshSSID;
+    TSTRING savedMeshPassword = _meshPassword;
+    TSTRING savedRouterSSID = routerSSID;
+    TSTRING savedRouterPassword = routerPassword;
+    Scheduler *savedScheduler = mScheduler;
+    auto savedBridgeRoleChangedCallback = bridgeRoleChangedCallback;
 
     // CRITICAL FIX: Schedule the stop/reinit work to run after current task completes
     // This prevents use-after-free crash when stop() clears taskList while
     // the retry task is still executing
     // Use minimal delay to allow current task to complete first
-    this->addTask(ASYNC_PROMOTION_DELAY_MS, TASK_ONCE, [this, savedChannel]() {
+    this->addTask(ASYNC_PROMOTION_DELAY_MS, TASK_ONCE,
+                  [this, savedChannel, savedMeshSSID, savedMeshPassword,
+                   savedRouterSSID, savedRouterPassword, savedScheduler,
+                   savedBridgeRoleChangedCallback]() {
       using namespace logger;
       
       Log(CONNECTION, "Executing isolated bridge promotion (stop/reinit cycle)\n");
@@ -2084,8 +2101,8 @@ class Mesh : public painlessmesh::Mesh<Connection> {
 
       // initAsBridge always returns true: bridge mesh functionality is active
       // regardless of router connection status (router connection is opportunistic)
-      this->initAsBridge(_meshSSID, _meshPassword, routerSSID, routerPassword,
-                         mScheduler, _meshPort);
+      this->initAsBridge(savedMeshSSID, savedMeshPassword, savedRouterSSID,
+                         savedRouterPassword, savedScheduler, _meshPort);
 
       // Reset retry counter
       _isolatedBridgeRetryAttempts = 0;
@@ -2095,10 +2112,9 @@ class Mesh : public painlessmesh::Mesh<Connection> {
           _meshChannel);
 
       // Notify via callback
-      // Use explicit TSTRING construction to ensure string lifetime safety
-      if (bridgeRoleChangedCallback) {
+      if (savedBridgeRoleChangedCallback) {
         static const TSTRING reason = "Isolated node promoted to bridge";
-        bridgeRoleChangedCallback(true, reason);
+        savedBridgeRoleChangedCallback(true, reason);
       }
 
       // Note: Bridge status announcement will be sent automatically by

--- a/src/painlessmesh/connection.hpp
+++ b/src/painlessmesh/connection.hpp
@@ -2,6 +2,8 @@
 #define _PAINLESS_MESH_CONNECTION_HPP_
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "Arduino.h"
 #include "painlessmesh/configuration.hpp"
@@ -46,6 +48,37 @@ extern uint32_t lastScheduledDeletionTime; // Timestamp of last deletion schedul
 
 // Shared buffer for reading/writing to the buffer
 extern painlessmesh::buffer::temp_buffer_t shared_buffer;
+
+// --- Local Fix  for use-after-free in Task::disable() (upstream issue #373) ---
+// Task::disable() writes on instance AFTER the task has been deleted. This is a use-after-free (UAF) bug in AsyncTCP.
+// return: deleting "this" inside its own onDisable is therefore a UAF
+// guaranteed. Return the deletion queue for AsyncClient cleanup tasks. This queue is processed by a dedicated "reaper" task that runs 
+// in the scheduler's main loop, ensuring that deletions occur outside of the disable() stack context of the task being deleted.
+//  This prevents use-after-free issues and ensures safe cleanup of AsyncClient instances.
+inline std::vector<std::pair<Task*, Scheduler*>>& pendingTaskDeletions() {
+  static std::vector<std::pair<Task*, Scheduler*>> v;
+  return v;
+}
+
+inline void ensureCleanupReaper(Scheduler* scheduler) {
+  static bool started = false;
+  if (started) return;
+  started = true;
+  static Task reaper(50 * TASK_MILLISECOND, TASK_FOREVER, []() {
+    auto& q = pendingTaskDeletions();
+    if (q.empty()) return;
+    // a copy and empty before run, for security against 
+    // any new scheduling triggered indirectly by the deletes. 
+    std::vector<std::pair<Task*, Scheduler*>> toDelete;
+    toDelete.swap(q);
+    for (auto& p : toDelete) {
+      p.second->deleteTask(*p.first);
+      delete p.first;
+    }
+  });
+  scheduler->addTask(reaper);
+  reaper.enable();
+}
 
 /**
  * Schedule deletion of an AsyncClient with proper spacing to prevent concurrent cleanups
@@ -123,12 +156,12 @@ inline void scheduleAsyncClientDeletion(Scheduler* scheduler, AsyncClient* clien
     delete client;
   });
 
-  // Self-cleanup: after execution, remove from scheduler and delete the Task.
-  // OnDisable fires after a TASK_ONCE task completes its single iteration.
+  // Don't delete the instance here (see issue #373): we just enqueue it for deletion by the reaper task
+  // the actual deletion is done by the reaper task outside the disable() stack.
   cleanupTask->setOnDisable([cleanupTask, scheduler]() {
-    scheduler->deleteTask(*cleanupTask);
-    delete cleanupTask;
+    pendingTaskDeletions().push_back({cleanupTask, scheduler});
   });
+  ensureCleanupReaper(scheduler);
 
   scheduler->addTask(*cleanupTask);
   cleanupTask->enableDelayed();

--- a/src/painlessmesh/connection.hpp
+++ b/src/painlessmesh/connection.hpp
@@ -193,13 +193,28 @@ class BufferedConnection
     using namespace logger;
     Log.remote("~BufferedConnection");
     this->close();
-    if (!client->freeable()) {
-      client->close(true);
-    }
+    // Always call client->close() here, unconditionally - do NOT guard this
+    // behind client->freeable(). freeable() can return true while _pcb is
+    // still a valid, non-null pointer (e.g. pcb->state == CLOSED but not yet
+    // reclaimed by lwIP). If we skip close() in that case, _pcb stays
+    // non-null for the entire TCP_CLIENT_CLEANUP_DELAY_MS+ deferred-deletion
+    // window below - during which lwIP's own internal timers (e.g. TIME_WAIT
+    // expiry) can silently free/recycle that pcb without ever notifying
+    // AsyncClient (the tcp_err callback only fires on abnormal termination,
+    // not on routine timer-driven pcb reclamation). The deferred delete then
+    // finds a stale-but-non-null _pcb and tries to close/free it a second
+    // time, corrupting the heap (observed as heap_caps_free/memp_free
+    // assertion failures and wild-pointer crashes inside tcp_arg(), all
+    // several seconds after the connection actually died).
+    // close() internally handles "nothing to do" safely (AsyncTCP checks
+    // _pcb/*pcb before touching lwIP state), and reliably nulls _pcb via its
+    // synchronous tcpip_api_call round-trip - so calling it unconditionally
+    // here, right at destruction time, closes this exposure window entirely.
+    client->close();
     // Note: client->abort() removed - calling it before deferred deletion
     // can leave the client in an inconsistent state where AsyncTCP is still
-    // trying to clean up the aborted connection. The close() and close(true)
-    // calls above are sufficient for connection termination.
+    // trying to clean up the aborted connection. The close() call above is
+    // sufficient for connection termination.
     // See: AsyncTCP best practices - abort() should only be called immediately
     // before delete, not before a deferred deletion.
     

--- a/src/painlessmesh/mesh.hpp
+++ b/src/painlessmesh/mesh.hpp
@@ -344,7 +344,7 @@ class Mesh : public ntp::MeshTime, public plugin::PackageHandler<T> {
       (*conn)->close();
       this->eraseClosedConnections();
     }
-    plugin::PackageHandler<T>::stop();
+    plugin::PackageHandler<T>::stop(mScheduler);
 
     newConnectionCallbacks.clear();
     droppedConnectionCallbacks.clear();

--- a/src/painlessmesh/plugin.hpp
+++ b/src/painlessmesh/plugin.hpp
@@ -173,12 +173,34 @@ class BridgeCoordinationPackage : public plugin::BroadcastPackage {
 template <typename T>
 class PackageHandler : public layout::Layout<T> {
  public:
-  void stop() {
-    for (auto&& task : taskList) {
-      task->disable();
-      task->setCallback(NULL);
+  // NOTA: scheduler e' opzionale (default nullptr) per compatibilita' con
+  // le chiamate esistenti nella libreria; senza di esso non possiamo
+  // rilevare la task "corrente" e il comportamento resta quello originale.
+  // Passare lo scheduler (es. mesh.hpp gia' lo ha come mScheduler) evita
+  // pero' lo use-after-free descritto sotto.
+  void stop(Scheduler* scheduler = nullptr) {
+    // Se stop() viene chiamata da dentro il callback di una delle task in
+    // taskList (es. promoteToBridge()), quella task e' "this->getCurrentTask()"
+    // dello scheduler in questo preciso momento. Disabilitarla/azzerarne il
+    // callback o farne scendere a zero il refcount qui distruggerebbe la sua
+    // closure - che e' ancora sullo stack, nel bel mezzo della sua stessa
+    // esecuzione - causando un crash use-after-free (stessa famiglia del bug
+    // upstream #373, ma innescata dal refcount dello shared_ptr invece che
+    // da un delete diretto in onDisable).
+    // La lasciamo semplicemente nella lista: addTask() la riconoscera' come
+    // "disabilitata e con un solo riferimento" e la riciclera' alla
+    // prossima chiamata, esattamente come gia' previsto per le task
+    // anonime disabilitate (vedi commento di addTask() sopra).
+    Task* current = scheduler ? scheduler->getCurrentTask() : nullptr;
+    for (auto it = taskList.begin(); it != taskList.end();) {
+      if (current != nullptr && it->get() == current) {
+        ++it;
+        continue;
+      }
+      (*it)->disable();
+      (*it)->setCallback(NULL);
+      it = taskList.erase(it);
     }
-    taskList.clear();
     callbackList.clear();
   }
 

--- a/src/painlessmesh/plugin.hpp
+++ b/src/painlessmesh/plugin.hpp
@@ -173,24 +173,24 @@ class BridgeCoordinationPackage : public plugin::BroadcastPackage {
 template <typename T>
 class PackageHandler : public layout::Layout<T> {
  public:
-  // NOTA: scheduler e' opzionale (default nullptr) per compatibilita' con
-  // le chiamate esistenti nella libreria; senza di esso non possiamo
-  // rilevare la task "corrente" e il comportamento resta quello originale.
-  // Passare lo scheduler (es. mesh.hpp gia' lo ha come mScheduler) evita
-  // pero' lo use-after-free descritto sotto.
+  // NOTE: scheduler is optional (defaults to nullptr) for backward
+  // compatibility with existing call sites; without it we can't detect
+  // the "current" task and behaviour falls back to the original one.
+  // Passing the scheduler (mesh.hpp already has it as mScheduler) avoids
+  // the use-after-free described below.
   void stop(Scheduler* scheduler = nullptr) {
-    // Se stop() viene chiamata da dentro il callback di una delle task in
-    // taskList (es. promoteToBridge()), quella task e' "this->getCurrentTask()"
-    // dello scheduler in questo preciso momento. Disabilitarla/azzerarne il
-    // callback o farne scendere a zero il refcount qui distruggerebbe la sua
-    // closure - che e' ancora sullo stack, nel bel mezzo della sua stessa
-    // esecuzione - causando un crash use-after-free (stessa famiglia del bug
-    // upstream #373, ma innescata dal refcount dello shared_ptr invece che
-    // da un delete diretto in onDisable).
-    // La lasciamo semplicemente nella lista: addTask() la riconoscera' come
-    // "disabilitata e con un solo riferimento" e la riciclera' alla
-    // prossima chiamata, esattamente come gia' previsto per le task
-    // anonime disabilitate (vedi commento di addTask() sopra).
+    // If stop() is called from within the callback of one of the tasks in
+    // taskList (e.g. promoteToBridge()), that task is
+    // "scheduler->getCurrentTask()" at this exact moment. Disabling it,
+    // clearing its callback, or letting its shared_ptr refcount drop to
+    // zero here would destroy its closure - which is still on the stack,
+    // in the middle of its own execution - causing a use-after-free crash
+    // (same bug family as upstream issue #373, but triggered by the
+    // shared_ptr refcount instead of a raw delete in onDisable).
+    // We simply leave it in the list: addTask() will recognise it as
+    // "disabled with a single reference" and reuse it on the next call,
+    // exactly like it already does for disabled anonymous tasks (see the
+    // comment on addTask() above).
     Task* current = scheduler ? scheduler->getCurrentTask() : nullptr;
     for (auto it = taskList.begin(); it != taskList.end();) {
       if (current != nullptr && it->get() == current) {

--- a/src/painlessmesh/tcp.hpp
+++ b/src/painlessmesh/tcp.hpp
@@ -121,9 +121,33 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
   Log(CONNECTION, "tcp::connect(): Attempting connection to port %d (attempt %d/%d)\n",
       port, retryCount + 1, TCP_CONNECT_MAX_RETRIES + 1);
   
+  // Guard shared between onError and onConnect: under normal conditions a
+  // TCP connection attempt leads to only ONE of the two outcomes. But if
+  // WiFi drops right as the TCP handshake completes, AsyncTCP can queue
+  // BOTH events (connection succeeded at the TCP level + abort due to the
+  // WiFi link being lost) for the same AsyncClient, and both callbacks end
+  // up firing for the SAME object. Without this guard, the client would be
+  // "handed over" twice: once to a BufferedConnection (via onConnect, which
+  // becomes its owner and will delete it via its own destructor) and once
+  // to the retry path (via onError, which schedules it again for deletion)
+  // - two scheduleAsyncClientDeletion() calls on the same pointer, and
+  // therefore a double deferred deletion on the same object once both
+  // tasks fire.
+  auto claimed = std::make_shared<bool>(false);
+  
   // Store retry count and connection parameters for the error handler
   // We need to capture these by value since they're used in the lambda
-  client.onError([&mesh, ip, port, retryCount](void *, AsyncClient *client, int8_t err) {
+  client.onError([&mesh, ip, port, retryCount, claimed](void *, AsyncClient *client, int8_t err) {
+    if (*claimed) {
+      // onConnect has already claimed this client (the connection actually
+      // succeeded, and it's already been wrapped in a BufferedConnection
+      // that owns it): don't touch the same object again.
+      Log(CONNECTION,
+          "tcp_err(): onError fired after onConnect had already claimed "
+          "the client - ignored to avoid double handling\n");
+      return;
+    }
+    *claimed = true;
     if (mesh.semaphoreTake()) {
       Log(CONNECTION, "tcp_err(): error trying to connect %d (attempt %d/%d)\n", 
           err, retryCount + 1, TCP_CONNECT_MAX_RETRIES + 1);
@@ -214,7 +238,26 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
   });
 
   client.onConnect(
-      [&mesh](void *, AsyncClient *client) {
+      [&mesh, claimed](void *, AsyncClient *client) {
+        if (*claimed) {
+          // onError has already fired for this client (e.g. an abort
+          // caused by losing WiFi right while the TCP handshake was
+          // completing): the client is already scheduled for deletion by
+          // the retry path. Wrapping it in a new BufferedConnection now
+          // would give it two owners at once. This connection did however
+          // genuinely succeed at the TCP level (that's why onConnect
+          // fired): close it explicitly here, so that when the deferred
+          // deletion already scheduled by onError fires, it finds a
+          // properly closed client instead of one still "connected" -
+          // otherwise we'd fall right back into the bug we're fixing.
+          Log(CONNECTION,
+              "tcp::connect(): onConnect fired after onError had already "
+              "claimed the client - closing the connection and discarding "
+              "it\n");
+          client->close();
+          return;
+        }
+        *claimed = true;
         if (mesh.semaphoreTake()) {
           Log(CONNECTION, "New STA connection incoming\n");
           auto conn = std::make_shared<T>(client, &mesh, true);


### PR DESCRIPTION
## Description

Fixes a family of use-after-free / heap-corruption crashes triggered when a
task, object, or connection is destroyed while something else still
depends on its state - surfaced in practice by a `LoadProhibited` panic
during bridge promotion after a router disconnect/reconnect cycle, and
later by a second family of crashes (`heap_caps_free`/`memp_free`
assertion failures, `tcp_arg()` wild-pointer stores) triggered when a mesh
node's TCP connection to a peer drops.

Five commits, addressing several different points in the same class of
problem:

**25638de** — `connection.hpp`: `scheduleAsyncClientDeletion()`'s
`cleanupTask` used to delete itself from inside its own `onDisable`
callback. `Task::disable()` keeps touching the task's members
(`iScheduler->iCurrent = current`) *after* `onDisable` returns, so deleting
`this` inside that callback is a guaranteed use-after-free. This is the bug
reported in #373. Fix: the cleanup task now queues itself for deletion
instead of self-deleting; a small reaper task (added once per Scheduler,
never destroyed - matching the "runs forever" nature of an ESP32 sketch)
performs the actual `delete` on its own scheduler pass, safely outside the
`disable()` call stack.

**b16739d** — `wifi.hpp`: `promoteToBridge()` (and the isolated-node retry
variant) schedule a delayed task that later reads `_meshSSID`,
`_meshPassword`, `routerSSID`, `routerPassword`, `mScheduler`, and
`bridgeRoleChangedCallback` through `this`. If anything disturbs `this` or
the closure's own storage in the delay window, those reads become
undefined behaviour. Fix: capture the values by copy into local variables
at scheduling time (when `this` is still guaranteed valid) and use those
copies inside the deferred lambda instead of re-reading through `this`
later. Defense-in-depth alongside the two fixes below, which address the
actual mechanism that was corrupting that state.

**d7c399a / 28b57ec** — `plugin.hpp` / `mesh.hpp`: the real root cause of
the bridge-promotion crash. `PackageHandler<T>::stop()` iterates `taskList`
and, for every task, calls `task->disable()`, `task->setCallback(NULL)`,
then drops all references via `taskList.clear()`. When `stop()` is called
from *within* the callback of one of those tasks (this happens in
`promoteToBridge()`: it schedules a deferred task whose own callback calls
`this->stop()`), the loop reaches the currently-executing task itself.
`setCallback(NULL)` destroys the `std::function` holding the running
closure, and/or `taskList.clear()` drops the last `shared_ptr<Task>`
reference and destroys the `Task` object - both while that very callback is
still on the call stack. This is the same bug family as #373, but
triggered via `shared_ptr` refcount / `setCallback(NULL)` instead of a raw
`delete` in `onDisable`. Notably, the existing code in `promoteToBridge()`
already has a comment acknowledging this exact class of bug and attempting
to work around it by deferring `stop()` to a separate task - but that
deferred task is itself tracked in the same `taskList`, so the existing
workaround doesn't fully close the gap.

Fix: `PackageHandler<T>::stop()` now optionally accepts the `Scheduler*` it
runs on. When provided, it uses the existing public
`Scheduler::getCurrentTask()` to detect whether a given task is the one
currently executing, and skips destroying it synchronously - it's left in
`taskList`, where the existing `addTask()` reuse logic (see the comment
above `addTask()`) safely recycles it once it's disabled and unreferenced
elsewhere. `Mesh<T>::stop()` passes `mScheduler` through. The `scheduler`
parameter defaults to `nullptr` for backward compatibility with any other
call sites.

**d7261f7** — `connection.hpp` + `tcp.hpp`: two more, independent bugs in
the same family, found once the four fixes above were deployed and the
originally-reported `LoadProhibited` panics stopped - but mesh nodes then
started crashing instead with `heap_caps_free`/`memp_free` assertion
failures and `tcp_arg()` wild-pointer stores.

*`connection.hpp`*: `~BufferedConnection()` only called `client->close()`
when `!client->freeable()`. `freeable()` returns `true` even while `_pcb`
is still a valid, non-null pointer (e.g. `pcb->state == CLOSED` but not yet
reclaimed by lwIP) - so `close()` was being skipped in that case, leaving
`_pcb` non-null-but-stale for the entire `TCP_CLIENT_CLEANUP_DELAY_MS`+
deferred-deletion window. During that window, lwIP's own internal timers
(e.g. TIME_WAIT expiry) can silently free/recycle that pcb without ever
notifying `AsyncClient` (`tcp_err` only fires on abnormal termination, not
on routine timer-driven reclamation). The deferred delete then found a
stale-but-non-null `_pcb` and tried to close/free it a second time,
corrupting the heap. Fix: call `client->close()` unconditionally in
`~BufferedConnection()`, regardless of `freeable()`. `close()` already
handles "nothing to do" safely and reliably nulls `_pcb` via its
synchronous `tcpip_api_call` round-trip - so calling it right at
destruction time closes the exposure window entirely.

*`tcp.hpp`*: a second, independent trigger for the same symptom family,
found via targeted logging after the fix above didn't fully eliminate the
crashes. `connect()` registers both `client.onError(...)` and
`client.onConnect(...)` unconditionally on the same `AsyncClient`. Under
normal conditions a connection attempt leads to only one of the two
outcomes - but if WiFi drops right as the TCP handshake completes, AsyncTCP
can queue *both* events for the same client, and both callbacks fire for
the same object. Without a guard, the client gets handed to two owners at
once: `onConnect` wraps it in a `BufferedConnection` (which will delete it
via its own destructor), while `onError` independently schedules it for
deletion via the retry path - producing two `scheduleAsyncClientDeletion()`
calls on the same pointer. Confirmed on hardware via temporary
instrumentation logging every scheduling call by pointer value: the same
address was scheduled twice, once by `tcp_err(retry)` and once by
`~BufferedConnection`, moments apart, matching a WiFi `BEACON_TIMEOUT`
event. Fix: a `shared_ptr<bool>` guard captured by both callbacks ensures
only the first one to fire claims and processes the client; if `onConnect`
loses the race (onError already claimed it), it explicitly closes the
now-orphaned-but-genuinely-connected client before discarding it, so the
already-scheduled deferred deletion later finds a properly closed client
instead of one still reported as `connected()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `connection.hpp` (#373 fix): verified with a dedicated regression test
  under AddressSanitizer. Against the original code, repeatedly tearing
  down `BufferedConnection` objects (simulating connection churn) reliably
  triggers a `heap-use-after-free` inside `Task::disable()`, matching the
  mechanism described above. With the fix applied, the same test passes
  clean under ASan.
- `plugin.hpp` / `mesh.hpp` fix: compiles cleanly across the full test
  suite; ran `catch_plugin`, `catch_bridge_coordination_callbacks`,
  `catch_bridge_status_broadcast`, and `catch_mesh_connectivity` - all
  existing tests pass unchanged. No dedicated regression test reproducing
  the exact self-destruct-during-`stop()` crash yet (would need a
  Boost-based harness driving `evaluateElection()`/`promoteToBridge()`
  end-to-end).
- `wifi.hpp` state-capture fix: field-tested on real ESP32 hardware
  (bridge node), reproducing router disconnect/reconnect cycles that
  previously crashed reliably.
- `connection.hpp` (`close()` fix) and `tcp.hpp` (`claimed` guard, commit
  d7261f7): field-tested on real ESP32-S3 hardware across bridge and leaf
  nodes. Root cause identified via temporary diagnostic logging (per-call
  `scheduleAsyncClientDeletion` pointer tracking with automatic
  double-schedule detection - since removed from the final commit), which
  confirmed the exact race described above. Reproduced reliably by
  powering off the bridge node while a leaf node was mid-reconnect; no
  crashes across multiple days of testing with both fixes applied, versus
  reliable crashes within hours without them. Also ran `catch_tcp`,
  `catch_tcp_retry`, `catch_tcp_blocklist`, `catch_tcp_integration`, and
  `catch_mesh_connectivity` - all existing tests pass unchanged
  (`catch_tcp_retry` in particular exercises the retry logic touched by
  the `tcp.hpp` fix).

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works *(partial - see above: connection.hpp's #373 fix has an ASan regression test; the other fixes are validated via existing test suites plus multi-day field testing on real hardware, but don't have dedicated new regression tests)*
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

Relates to #373 (same root-cause bug class - a task/object destroyed while
something still depends on its state - across multiple different trigger
sites: `onDisable` self-delete, `PackageHandler::stop()` self-destruct,
and a `freeable()`-guarded `close()` skip / `onError`+`onConnect` race in
the TCP connection lifecycle)