### PR TITLE
fix(examples): qualify plugin:: namespace in bridge_failover sketch (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bridge_failover` example failed to compile (#360)** — the two
+  `mesh.onBridgeCoordination*` lambdas referenced
+  `plugin::BridgeCoordinationPackage` with a bare `plugin::` prefix, but
+  `painlessMesh.h` only lifts `painlessmesh::logger` to global scope, so
+  the type did not resolve (`'plugin' does not name a type`). Both lambda
+  parameters are now fully qualified as
+  `painlessmesh::plugin::BridgeCoordinationPackage`, matching the
+  convention used across every other example (otaSender, namedMesh,
+  alteriom_*).
+
 ## [1.9.21] - 2026-08-04
 
 Crash-fix release resolving a family of use-after-free bugs in the task and

--- a/examples/bridge_failover/bridge_failover.ino
+++ b/examples/bridge_failover/bridge_failover.ino
@@ -240,7 +240,7 @@ void setup() {
 
   // Monitor bridge coordination (fires every ~30s per bridge)
   mesh.onBridgeCoordination(
-    [](const plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
+    [](const painlessmesh::plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
       Serial.printf("Bridge %u: priority=%d, load=%d%%\n",
                     fromNode, pkg.priority, pkg.load);
     }
@@ -248,7 +248,7 @@ void setup() {
 
   // Get notified when bridge state changes (new/updated/lost)
   mesh.onBridgeCoordinationChanged(
-    [](const plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode,
+    [](const painlessmesh::plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode,
        TSTRING changeType) {
       Serial.printf("Bridge %s: %u (role=%s)\n",
                     changeType.c_str(), fromNode, pkg.role.c_str());


### PR DESCRIPTION
## Summary
Fixes #360 — the `bridge_failover.ino` example fails to compile with:

```
error: 'plugin' does not name a type
  [](const plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
           ^~~~~~
```

## Root cause
The lambda parameter uses `plugin::BridgeCoordinationPackage` — an unqualified `plugin::` prefix. But `plugin` is nested inside `painlessmesh::`, and `painlessMesh.h` does **not** issue a `using namespace painlessmesh;` (only `using namespace painlessmesh::logger;`). So at sketch (global) scope, the bare `plugin::` name is not visible and the compile fails.

## Fix
Fully qualify both lambda parameters as `painlessmesh::plugin::BridgeCoordinationPackage`. This matches the convention already used by every other example in the repo:

- `examples/otaSender/otaSender.ino` — `painlessmesh::plugin::ota::DataRequest`
- `examples/namedMesh/namedMesh.ino` — `painlessmesh::plugin::NeighbourPackage`
- `examples/alteriom/*` — all use `painlessmesh::plugin::…`

Two-line change, no runtime behavior affected.

## Test plan
- [ ] Compile `examples/bridge_failover/bridge_failover.ino` on Arduino IDE 2.3.8 with ESP32 core 3.3.7 — should build cleanly (the reproduction environment from the issue).

Closes #360