### PR TITLE
fix(examples): qualify plugin::BridgeCoordinationPackage in bridge_failover (#360)

### DIFF
--- a/examples/bridge_failover/bridge_failover.ino
+++ b/examples/bridge_failover/bridge_failover.ino
@@ -240,7 +240,7 @@ void setup() {
 
   // Monitor bridge coordination (fires every ~30s per bridge)
   mesh.onBridgeCoordination(
-    [](const plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
+    [](const painlessmesh::plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
       Serial.printf("Bridge %u: priority=%d, load=%d%%\n",
                     fromNode, pkg.priority, pkg.load);
     }
@@ -248,7 +248,7 @@ void setup() {
 
   // Get notified when bridge state changes (new/updated/lost)
   mesh.onBridgeCoordinationChanged(
-    [](const plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode,
+    [](const painlessmesh::plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode,
        TSTRING changeType) {
       Serial.printf("Bridge %s: %u (role=%s)\n",
                     changeType.c_str(), fromNode, pkg.role.c_str());


### PR DESCRIPTION
## Problem

Reported in #360: compiling `examples/bridge_failover/bridge_failover.ino`
under Arduino IDE 2.3.8 / ESP32 core 3.3.7 fails with:

```
error: 'plugin' does not name a type
    [](const plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
             ^~~~~~
```

## Cause

`BridgeCoordinationPackage` lives in `namespace painlessmesh::plugin`. The
main `painlessMesh.h` header exposes only `painlessmesh::logger` at global
scope (`using namespace painlessmesh::logger;`) — the `plugin` namespace is
NOT lifted into the sketch's global scope, so the bare `plugin::` prefix
does not resolve.

Every other example in the repo already uses the fully-qualified form:

- `examples/otaSender/otaSender.ino` → `painlessmesh::plugin::ota::DataRequest`
- `examples/namedMesh/namedMesh.ino` → `painlessmesh::plugin::NeighbourPackage`
- `examples/alteriom/alteriom_sensor_package.hpp` (and 10+ others) →
  `painlessmesh::plugin::BroadcastPackage`, `painlessmesh::plugin::SinglePackage`

Only `bridge_failover.ino` used the bare form.

## Fix

Qualify the two lambda parameter types with `painlessmesh::` — matching
the convention already in use across the rest of the examples. No
library / API change.

```diff
-    [](const plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
+    [](const painlessmesh::plugin::BridgeCoordinationPackage& pkg, uint32_t fromNode) {
```

## Verification

- Manual inspection of `src/painlessMesh.h` (line 56) confirms only
  `painlessmesh::logger` is `using namespace`-lifted; `plugin` is not.
- `grep` of `examples/**` shows every other example already uses
  `painlessmesh::plugin::*` — this change makes bridge_failover consistent.
- The lambda captures/body are untouched; only the parameter type is
  requalified.

Closes #360