### PR TITLE
ci(release): fail fast on invalid NPM_TOKEN (refs #381)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
           exit 1
         fi
         echo "🔎 Validating NPM_TOKEN against registry (npm whoami)..."
-        if ! WHOAMI_OUT=$(npm whoami 2>&1); then
+        if ! WHOAMI_OUT=$(npm whoami --registry=https://registry.npmjs.org 2>&1); then
           echo "❌ NPM_TOKEN is set but invalid (npm whoami failed):"
           echo "$WHOAMI_OUT"
           echo ""
@@ -377,4 +377,3 @@ jobs:
         echo ""
         echo "💡 Note: GitHub Packages require authentication for installation"
         echo "================================"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,11 +235,19 @@ jobs:
           echo "2. Add NPM_TOKEN with your NPM access token"
           echo "3. Generate token at: https://www.npmjs.com/settings/tokens"
           exit 1
-        else
-          echo "✅ NPM authentication token is configured"
-          # Test authentication without publishing
-          npm whoami || echo "NPM authentication test completed"
         fi
+        echo "🔎 Validating NPM_TOKEN against registry (npm whoami)..."
+        if ! WHOAMI_OUT=$(npm whoami 2>&1); then
+          echo "❌ NPM_TOKEN is set but invalid (npm whoami failed):"
+          echo "$WHOAMI_OUT"
+          echo ""
+          echo "The token has likely expired or been revoked. To fix:"
+          echo "1. Mint a new automation token at https://www.npmjs.com/settings/tokens"
+          echo "2. Update the NPM_TOKEN secret in repository settings"
+          echo "3. Re-run this workflow"
+          exit 1
+        fi
+        echo "✅ Authenticated to NPM as: $WHOAMI_OUT"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     


### PR DESCRIPTION
## Summary

The `Verify NPM authentication` step in `release.yml` previously ran:

```bash
npm whoami || echo "NPM authentication test completed"
```

The `|| echo` swallows the failure — the step passes even when the token is invalid, and the 401 surfaces late at the `npm publish` call (as it did for v1.9.21, see #381).

This PR makes the step **fail hard** when `npm whoami` returns non-zero, and prints operator remediation steps (mint new token → update `NPM_TOKEN` → re-run) inline in the failing step so it's obvious what to do.

**Not fixed here:** the actual `NPM_TOKEN` rotation. That is operator-only — see #381 for the outstanding ask.

**Also flagged in #381** but out of scope for this PR: the `release: published` → `platformio-publish.yml` trigger suppression issue. That deserves its own change.

## Test plan

- [ ] CI green
- [ ] Once `NPM_TOKEN` is rotated (#381), the next release run should pass the whoami check and print `✅ Authenticated to NPM as: <user>`
- [ ] If someone lets the token expire again, this step surfaces the failure immediately with a clear remediation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)