### PR TITLE
docs(message-queue): document as manual buffer + retire dead safety constants as deprecated no-ops (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the `flushMessageQueue` example shows the intended pattern of
   wiring the drain into `onLocalInternetChanged`.
 
-### Removed
+### Deprecated
 
-- **Dead safety knobs `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` (#385)** —
-  these `#define`s in `painlessmesh/configuration.hpp` (and the
-  duplicated definitions in `test/boost/Arduino.h`) were read by nothing
-  in the tree. They were placeholders for the auto-flush behavior that
-  never landed. `MessageQueue` has always taken its own per-instance
-  `maxSize` constructor argument. Removing them prevents downstream
-  users from tuning knobs that do nothing. If your application defined
-  either macro before including painlessMesh, it can be safely deleted.
+- **Compatibility queue macros kept as ignored no-ops (#385)** —
+  `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` remain defined in
+  `painlessmesh/configuration.hpp` (and `test/boost/Arduino.h`) for
+  source compatibility, but nothing in the library reads them. They were
+  placeholders for the auto-flush behavior that never landed.
+  `MessageQueue` has always taken its own per-instance `maxSize`
+  constructor argument.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`MessageQueue` documented honestly as a manual buffer (#385)** —
+  removed the "messages are automatically delivered when connection is
+  restored" claim from `MessageQueue` and the `mesh.enableMessageQueue`
+  / `queueMessage` / `flushMessageQueue` doc comments. Nothing in the
+  library ever transmitted queued messages or observed connectivity
+  changes; the app has always owned the send loop. The docs now say so,
+  and the `flushMessageQueue` example shows the intended pattern of
+  wiring the drain into `onLocalInternetChanged`.
+
+### Removed
+
+- **Dead safety knobs `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` (#385)** —
+  these `#define`s in `painlessmesh/configuration.hpp` (and the
+  duplicated definitions in `test/boost/Arduino.h`) were read by nothing
+  in the tree. They were placeholders for the auto-flush behavior that
+  never landed. `MessageQueue` has always taken its own per-instance
+  `maxSize` constructor argument. Removing them prevents downstream
+  users from tuning knobs that do nothing. If your application defined
+  either macro before including painlessMesh, it can be safely deleted.
+
 ### Fixed
 
 - **`bridge_failover` example failed to compile (#360)** — the two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source compatibility, but nothing in the library reads them. They were
   placeholders for the auto-flush behavior that never landed.
   `MessageQueue` has always taken its own per-instance `maxSize`
-  constructor argument.
+  constructor argument. Their historical default values
+  (`MIN_FREE_MEMORY 4000`, `MAX_MESSAGE_QUEUE 50`) are preserved so any
+  downstream code that referenced the macros keeps its prior behavior.
 
 ### Fixed
 

--- a/src/painlessmesh/configuration.hpp
+++ b/src/painlessmesh/configuration.hpp
@@ -26,12 +26,19 @@
 // Enable OTA support
 #define PAINLESSMESH_ENABLE_OTA
 
-// NOTE: `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` used to live here as
-// safety knobs for an auto-flushing message queue that never landed
-// (see #385, PR #383 review). They were read by nothing in the library
-// and were removed to avoid implying behavior that does not exist. The
-// `MessageQueue` class (`painlessmesh/message_queue.hpp`) is a manual
-// priority buffer with its own per-instance `maxSize` argument.
+// NOTE: `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` are kept as deprecated
+// no-op compatibility macros. The library does not read either macro:
+// the auto-flushing message queue they were meant to tune never landed
+// (see #385, PR #383 review). `MessageQueue`
+// (`painlessmesh/message_queue.hpp`) is a manual priority buffer with
+// its own per-instance `maxSize` argument.
+#ifndef MIN_FREE_MEMORY
+#define MIN_FREE_MEMORY 4000
+#endif
+
+#ifndef MAX_MESSAGE_QUEUE
+#define MAX_MESSAGE_QUEUE 1000
+#endif
 
 #define NODE_TIMEOUT 10 * TASK_SECOND
 #define SCAN_INTERVAL 30 * TASK_SECOND  // AP scan period in ms

--- a/src/painlessmesh/configuration.hpp
+++ b/src/painlessmesh/configuration.hpp
@@ -31,13 +31,15 @@
 // the auto-flushing message queue they were meant to tune never landed
 // (see #385, PR #383 review). `MessageQueue`
 // (`painlessmesh/message_queue.hpp`) is a manual priority buffer with
-// its own per-instance `maxSize` argument.
+// its own per-instance `maxSize` argument. Their historical default
+// values are preserved so downstream code that referenced them keeps
+// its prior behavior.
 #ifndef MIN_FREE_MEMORY
 #define MIN_FREE_MEMORY 4000
 #endif
 
 #ifndef MAX_MESSAGE_QUEUE
-#define MAX_MESSAGE_QUEUE 1000
+#define MAX_MESSAGE_QUEUE 50
 #endif
 
 #define NODE_TIMEOUT 10 * TASK_SECOND

--- a/src/painlessmesh/configuration.hpp
+++ b/src/painlessmesh/configuration.hpp
@@ -26,10 +26,12 @@
 // Enable OTA support
 #define PAINLESSMESH_ENABLE_OTA
 
-// Minimum free memory, besides here all packets in queue are discarded.
-#define MIN_FREE_MEMORY 4000
-// MAX number of unsent messages in queue. Newer messages are discarded
-#define MAX_MESSAGE_QUEUE 50
+// NOTE: `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` used to live here as
+// safety knobs for an auto-flushing message queue that never landed
+// (see #385, PR #383 review). They were read by nothing in the library
+// and were removed to avoid implying behavior that does not exist. The
+// `MessageQueue` class (`painlessmesh/message_queue.hpp`) is a manual
+// priority buffer with its own per-instance `maxSize` argument.
 
 #define NODE_TIMEOUT 10 * TASK_SECOND
 #define SCAN_INTERVAL 30 * TASK_SECOND  // AP scan period in ms

--- a/src/painlessmesh/mesh.hpp
+++ b/src/painlessmesh/mesh.hpp
@@ -2060,16 +2060,33 @@ class Mesh : public ntp::MeshTime, public plugin::PackageHandler<T> {
   //
   
   /**
-   * Enable or disable message queueing for offline mode
-   * 
-   * When enabled, messages can be queued when Internet is unavailable
-   * and automatically flushed when connection is restored.
-   * 
+   * Enable or disable the manual message queue for offline mode
+   *
+   * When enabled, allocates a `MessageQueue` that your application can
+   * push into while an upstream (MQTT/HTTP/etc.) is unreachable. The
+   * mesh does NOT flush the queue automatically and does NOT observe
+   * connectivity changes — the app is responsible for detecting when
+   * to drain it via `flushMessageQueue()` + `removeQueuedMessage()`.
+   *
+   * Wire it to your own connectivity signal, for example
+   * `onLocalInternetChanged` on the bridge node or
+   * `onBridgeStatusChanged` on downstream nodes.
+   *
    * @param enabled True to enable queueing, false to disable
    * @param maxSize Maximum number of messages in queue (default 1000)
-   * 
+   *
    * \code
    * mesh.enableMessageQueue(true, 500);  // Enable with 500 message capacity
+   *
+   * mesh.onLocalInternetChanged([&mesh](bool available) {
+   *   if (available) {
+   *     for (auto& msg : mesh.flushMessageQueue()) {
+   *       if (sendToCloud(msg.payload, msg.destination)) {
+   *         mesh.removeQueuedMessage(msg.id);
+   *       }
+   *     }
+   *   }
+   * });
    * \endcode
    */
   void enableMessageQueue(bool enabled, uint32_t maxSize = 1000) {
@@ -2084,11 +2101,13 @@ class Mesh : public ntp::MeshTime, public plugin::PackageHandler<T> {
   }
   
   /**
-   * Queue a message with priority for later delivery
-   * 
-   * Use this to queue critical messages when Internet is unavailable.
-   * Messages are automatically delivered when connection is restored.
-   * 
+   * Queue a message with priority for later manual delivery
+   *
+   * Use this to buffer critical messages when your upstream
+   * (MQTT/HTTP/etc.) is unavailable. The library does NOT deliver these
+   * on its own — your app must call `flushMessageQueue()` and
+   * `removeQueuedMessage()` once its own connectivity check clears.
+   *
    * @param payload Message content to queue
    * @param destination Optional destination metadata (e.g., MQTT topic, HTTP endpoint)
    * @param priority Message priority (default: PRIORITY_NORMAL)
@@ -2115,16 +2134,14 @@ class Mesh : public ntp::MeshTime, public plugin::PackageHandler<T> {
   }
   
   /**
-   * Flush all queued messages
-   * 
-   * Attempts to send all queued messages. This is typically called
-   * automatically when Internet connection is restored, but can be
-   * called manually.
-   * 
-   * Note: This returns the messages for the application to send.
-   * The application is responsible for actually transmitting them
-   * and calling removeQueuedMessage() when successful.
-   * 
+   * Return a snapshot of all queued messages for manual delivery
+   *
+   * This does NOT transmit anything and does NOT clear the queue. The
+   * application is responsible for actually sending each message and
+   * calling `removeQueuedMessage(id)` for each one that succeeded.
+   * Messages left in the queue remain available for retry on the next
+   * flush.
+   *
    * @return Vector of queued messages to send
    * 
    * \code

--- a/src/painlessmesh/mesh.hpp
+++ b/src/painlessmesh/mesh.hpp
@@ -2080,7 +2080,8 @@ class Mesh : public ntp::MeshTime, public plugin::PackageHandler<T> {
    *
    * mesh.onLocalInternetChanged([&mesh](bool available) {
    *   if (available) {
-   *     for (auto& msg : mesh.flushMessageQueue()) {
+   *     auto messages = mesh.flushMessageQueue();
+   *     for (auto& msg : messages) {
    *       if (sendToCloud(msg.payload, msg.destination)) {
    *         mesh.removeQueuedMessage(msg.id);
    *       }

--- a/src/painlessmesh/message_queue.hpp
+++ b/src/painlessmesh/message_queue.hpp
@@ -101,7 +101,8 @@ typedef std::function<void(QueueState state, uint32_t messageCount)> queueStateC
  * uint32_t size = queue.size();
  *
  * // When your app detects the upstream is back, drain manually:
- * for (auto& msg : queue.getMessages()) {
+ * auto messages = queue.getMessages();
+ * for (auto& msg : messages) {
  *   if (sendToCloud(msg.payload, msg.destination)) {
  *     queue.remove(msg.id);
  *   }

--- a/src/painlessmesh/message_queue.hpp
+++ b/src/painlessmesh/message_queue.hpp
@@ -73,29 +73,38 @@ struct QueueStats {
 typedef std::function<void(QueueState state, uint32_t messageCount)> queueStateChangedCallback_t;
 
 /**
- * Message Queue for offline/Internet-unavailable mode
- * 
+ * Manual priority buffer for offline / Internet-unavailable mode
+ *
+ * This is a *storage* container only. It does NOT transmit anything on
+ * its own: painlessMesh will not enqueue, flush, or deliver messages
+ * automatically, and there is no connectivity-restored trigger inside
+ * the library. The application owns the send loop — enqueue when your
+ * upstream (MQTT/HTTP/etc.) is down, drain via `getMessages()` /
+ * `mesh.flushMessageQueue()` and `remove()` / `mesh.removeQueuedMessage()`
+ * when your own connectivity check tells you it is safe to resend.
+ *
  * Provides priority-based message queueing with support for:
  * - Priority levels (CRITICAL messages never dropped)
  * - Queue size limits with intelligent eviction
  * - Statistics tracking
  * - State change callbacks
- * 
+ *
  * Example usage:
  * \code
  * MessageQueue queue(1000);  // Max 1000 messages
- * 
- * // Queue a critical message
+ *
+ * // Queue a critical message while upstream is offline
  * uint32_t msgId = queue.enqueue(PRIORITY_CRITICAL, "alarm_data", "mqtt://...");
- * 
+ *
  * // Get queue size
  * uint32_t size = queue.size();
- * 
- * // Get all messages (for sending)
- * std::vector<QueuedMessage> messages = queue.getMessages();
- * 
- * // Remove sent message
- * queue.remove(msgId);
+ *
+ * // When your app detects the upstream is back, drain manually:
+ * for (auto& msg : queue.getMessages()) {
+ *   if (sendToCloud(msg.payload, msg.destination)) {
+ *     queue.remove(msg.id);
+ *   }
+ * }
  * \endcode
  */
 class MessageQueue {

--- a/src/painlessmesh/message_queue.hpp
+++ b/src/painlessmesh/message_queue.hpp
@@ -84,7 +84,8 @@ typedef std::function<void(QueueState state, uint32_t messageCount)> queueStateC
  * when your own connectivity check tells you it is safe to resend.
  *
  * Provides priority-based message queueing with support for:
- * - Priority levels (CRITICAL messages never dropped)
+ * - Priority levels (CRITICAL messages evicted last, but may still be dropped
+ *   if the queue is full and all entries are CRITICAL)
  * - Queue size limits with intelligent eviction
  * - Statistics tracking
  * - State change callbacks

--- a/test/boost/Arduino.h
+++ b/test/boost/Arduino.h
@@ -83,10 +83,6 @@ inline void yield() {}
 #define PAINLESSMESH_ENABLE_STD_STRING
 #define PAINLESSMESH_ENABLE_OTA
 #define NODE_TIMEOUT 10 * TASK_SECOND
-// Minimum free memory, besides here all packets in queue are discarded.
-#define MIN_FREE_MEMORY 4000
-// MAX number of unsent messages in queue. Newer messages are discarded
-#define MAX_MESSAGE_QUEUE 50
 
 typedef std::string TSTRING;
 

--- a/test/boost/Arduino.h
+++ b/test/boost/Arduino.h
@@ -89,7 +89,7 @@ inline void yield() {}
 #endif
 
 #ifndef MAX_MESSAGE_QUEUE
-#define MAX_MESSAGE_QUEUE 1000
+#define MAX_MESSAGE_QUEUE 50
 #endif
 
 typedef std::string TSTRING;

--- a/test/boost/Arduino.h
+++ b/test/boost/Arduino.h
@@ -84,6 +84,14 @@ inline void yield() {}
 #define PAINLESSMESH_ENABLE_OTA
 #define NODE_TIMEOUT 10 * TASK_SECOND
 
+#ifndef MIN_FREE_MEMORY
+#define MIN_FREE_MEMORY 4000
+#endif
+
+#ifndef MAX_MESSAGE_QUEUE
+#define MAX_MESSAGE_QUEUE 1000
+#endif
+
 typedef std::string TSTRING;
 
 #ifdef ESP32


### PR DESCRIPTION
## Why

From issue #385 (raised in the PR #383 v2.x deep review):

- `MessageQueue` is a complete, unit-tested public API, but nothing in `sendSingle` / `sendBroadcast` / `routePackage` ever calls into it, and no connectivity-restored trigger exists. Its doc comment nonetheless claimed *"Messages are automatically delivered when connection is restored"*, and the `mesh.enableMessageQueue` / `queueMessage` / `flushMessageQueue` doc block on `mesh.hpp` said the same thing. The app has always had to enqueue, poll, and resend itself.
- `MAX_MESSAGE_QUEUE` and `MIN_FREE_MEMORY` in `painlessmesh/configuration.hpp` (and the duplicated definitions in `test/boost/Arduino.h`) were read by nothing in the tree — dead safety knobs left over from an auto-flush behavior that never landed (see revert #75 / `bb3e57d` and closed-but-unimplemented #66).

The issue proposed two paths:
- **(a) Wire it for real** — internal flush task + connectivity detection + honor both macros.
- **(b) Rescope honestly** — document as a manual priority buffer, retire the dead constants.

This PR takes **option (b)**. It matches the P2-medium scope, avoids introducing new automatic behavior in a fix PR (which could surprise existing users that already manually manage the queue), and closes the gap the review flagged.

## What changed

**Docs (behavior-preserving):**
- `MessageQueue` class comment in `src/painlessmesh/message_queue.hpp` now says out loud that this is a *manual priority buffer* — painlessMesh does not transmit, flush, or observe connectivity for it. The example shows draining via `getMessages()` + `remove()`. The priority note also states honestly that CRITICAL messages are evicted last but can still be dropped when the queue is full of CRITICAL entries (matches `makeSpace()` eviction behavior).
- `mesh.enableMessageQueue` doc comment loses the "automatically flushed when connection is restored" claim and gains a worked example wiring the drain into `onLocalInternetChanged` — the pattern the API was always intended to support.
- `queueMessage` doc drops the "automatically delivered" line and calls the manual contract out explicitly.
- `flushMessageQueue` doc drops the self-contradictory "typically called automatically … application is responsible for actually transmitting them" language.
- All three drain examples snapshot the by-value `flushMessageQueue()` / `getMessages()` return into a named variable before iterating, so readers don't accidentally hold references/iterators into a temporary.

**Dead constants (no functional change):**
- `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` are **kept as deprecated, no-op compatibility macros** in `src/painlessmesh/configuration.hpp` (and `test/boost/Arduino.h`), each guarded with `#ifndef`. Nothing in the library reads either macro — they were placeholders for the auto-flush behavior that never landed. Rather than hard-delete them from a public header (a source-breaking change for downstream code that referenced them), they remain defined with an explanatory note so they can be removed in a later release cycle. `MessageQueue` continues to take its own per-instance `maxSize` constructor argument (default 1000).

**Changelog:** `[Unreleased]` gets a **Changed** entry (docs) and a **Deprecated** entry (the macros retained as ignored no-ops).

## What did not change

- `MessageQueue`'s public API is unchanged.
- All mesh queue methods on `mesh.hpp` are unchanged.
- Existing unit tests (`catch_message_queue.cpp`, `catch_priority_send.cpp`) do not reference either macro.
- `MessageQueue` still enforces its own per-instance `maxSize` (constructor argument, default 1000).

## Migration

No action is required: `MIN_FREE_MEMORY` and `MAX_MESSAGE_QUEUE` remain defined but ignored, so existing downstream `#define`s keep compiling. Nothing in the library ever read them, so they can be deleted from your code at any time. To bound the queue, pass the size to `enableMessageQueue(true, /* maxSize */ 200)` or to the `MessageQueue` constructor.

## Test plan

- [ ] `catch_message_queue` and `catch_priority_send` continue to pass under CI's Catch2 build.
- [ ] Boost/TCP integration tests continue to build after the mock-header cleanup.
- [ ] PlatformIO ESP32 / ESP8266 envs compile — the retained macros are ignored and referenced nowhere else in the tree.

Closes #385
Related: #383 (v2.x deep review), #75 (previous queue revert), #66 (closed offline-queuing issue whose automation never landed).

Generated with Claude Code
