### PR TITLE
feat(tcp): expose TCP retry parameters as user-configurable settings (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **User-configurable TCP retry parameters (#378)** — the five TCP connect
+  retry values that were hardcoded as `static const` in
+  `src/painlessmesh/tcp.hpp` are now tunable per mesh instance via
+  `mesh.setTcpRetryConfig()` / `mesh.getTcpRetryConfig()`, using the new
+  `painlessmesh::tcp::TcpRetryConfig` struct (`maxRetries`, `retryDelayMs`,
+  `stabilizationDelayMs`, `exhaustionReconnectDelayMs`,
+  `failureBlockDurationMs`). This lets latency-sensitive meshes (see
+  discussion #368), high-reliability industrial deployments and
+  battery-powered nodes each pick their own retry envelope without forking
+  the library.
+
+  The struct's defaults are spelled as the existing constants, so **behaviour
+  is unchanged for any sketch that does not call the new setter**, and the
+  constants themselves remain in place. `maxRetries` is clamped to 10 and
+  `retryDelayMs` to 50–60000 ms, since an unbounded retry count is a
+  heap/recursion hazard and a zero delay produces a hot reconnect loop; the
+  remaining fields accept 0 as a meaningful "disable this step" value.
+  New `examples/tcpRetryConfig/` demonstrates real-time, high-reliability and
+  battery-saver profiles.
+
 ### Changed
 
 ### Fixed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -492,6 +492,47 @@ void setDebugMsgTypes(uint16_t types);
 mesh.setDebugMsgTypes(ERROR | STARTUP | CONNECTION);
 ```
 
+#### TCP Retry Configuration
+
+**`setTcpRetryConfig()`** / **`getTcpRetryConfig()`** - Tune how a node retries
+a failed TCP connection before falling back to a full WiFi reconnect.
+
+```cpp
+void setTcpRetryConfig(const painlessmesh::tcp::TcpRetryConfig& config);
+painlessmesh::tcp::TcpRetryConfig getTcpRetryConfig() const;
+```
+
+| Field | Default | Meaning |
+|---|---|---|
+| `maxRetries` | 5 | TCP connect attempts after the first before giving up |
+| `retryDelayMs` | 1000 | Base delay between retries; scaled 1x, 2x, 4x, 8x, 8x |
+| `stabilizationDelayMs` | 500 | Wait after IP acquisition before the first attempt |
+| `exhaustionReconnectDelayMs` | 10000 | Wait before the WiFi reconnect after exhaustion |
+| `failureBlockDurationMs` | 60000 | How long a failed peer is skipped during AP selection |
+
+The defaults reproduce the previous hardcoded behaviour exactly, so existing
+sketches see no change. Call this **before** `mesh.init()`.
+
+**Example** (real-time profile — fail fast and re-scan rather than stall):
+```cpp
+painlessmesh::tcp::TcpRetryConfig cfg;   // starts at the defaults
+cfg.maxRetries = 1;
+cfg.retryDelayMs = 200;
+cfg.exhaustionReconnectDelayMs = 1000;
+mesh.setTcpRetryConfig(cfg);
+
+mesh.init(MESH_PREFIX, MESH_PASSWORD, &userScheduler, MESH_PORT);
+```
+
+`maxRetries` is capped at 10 and `retryDelayMs` is held between 50 ms and
+60000 ms; use `getTcpRetryConfig()` to read back what actually took effect.
+See `examples/tcpRetryConfig/` for real-time, high-reliability and
+battery-saver profiles, and the API docs for the full tuning guidance.
+
+> **Note:** these defaults were deliberately raised in 1.9.x to fix real-world
+> mesh instability. Tuning them down can reintroduce connection churn and rapid
+> reconnect loops.
+
 ---
 
 ## Alteriom Extensions

--- a/docsify-site/api/configuration.md
+++ b/docsify-site/api/configuration.md
@@ -276,6 +276,87 @@ mesh.setNodeTimeout(5 * 1000000);
 mesh.setNodeTimeout(30 * 1000000);
 ```
 
+### setTcpRetryConfig()
+
+Tune how a node retries a failed TCP connection before falling back to a full
+WiFi reconnect.
+
+```cpp
+void mesh.setTcpRetryConfig(const painlessmesh::tcp::TcpRetryConfig& config)
+painlessmesh::tcp::TcpRetryConfig mesh.getTcpRetryConfig() const
+```
+
+**Fields:**
+
+| Field | Default | Meaning |
+|---|---|---|
+| `maxRetries` | 5 | TCP connect attempts after the first before giving up |
+| `retryDelayMs` | 1000 | Base delay between retries; scaled 1x, 2x, 4x, 8x, 8x |
+| `stabilizationDelayMs` | 500 | Wait after IP acquisition before the first attempt |
+| `exhaustionReconnectDelayMs` | 10000 | Wait before the WiFi reconnect that follows exhaustion |
+| `failureBlockDurationMs` | 60000 | How long a failed peer is skipped during AP selection |
+
+The defaults reproduce the previous hardcoded behaviour exactly — a sketch that
+never calls this sees no change. With them, a node that cannot reach its parent
+spends 1 + 2 + 4 + 8 + 8 = 23 s retrying, waits another 10 s before reconnecting
+WiFi, and will not re-select that peer for 60 s.
+
+Call this **before** `mesh.init()` so the first connection attempt already uses
+it.
+
+```cpp
+painlessmesh::tcp::TcpRetryConfig cfg;   // starts at the defaults
+cfg.maxRetries = 1;
+cfg.retryDelayMs = 200;
+cfg.exhaustionReconnectDelayMs = 1000;
+mesh.setTcpRetryConfig(cfg);
+
+mesh.init(MESH_PREFIX, MESH_PASSWORD, &userScheduler, MESH_PORT);
+```
+
+**Profiles:**
+
+| | Real-time | Default | High-reliability | Battery |
+|---|---|---|---|---|
+| `maxRetries` | 1 | 5 | 10 | 2 |
+| `retryDelayMs` | 200 | 1000 | 2000 | 3000 |
+| `stabilizationDelayMs` | 100 | 500 | 1000 | 500 |
+| `exhaustionReconnectDelayMs` | 1000 | 10000 | 30000 | 60000 |
+| `failureBlockDurationMs` | 5000 | 60000 | 180000 | 300000 |
+| worst-case retry time | 0.2 s | 23 s | 126 s | 9 s |
+
+See `examples/tcpRetryConfig/` for a runnable sketch with all three.
+
+**Clamping:**
+
+Two values are coerced into safe bounds, because they can otherwise render a
+node unusable:
+
+- `maxRetries` is capped at **10** — each retry allocates an `AsyncClient` and
+  schedules a task, so an unbounded value is a heap and recursion-depth hazard
+  on ESP8266.
+- `retryDelayMs` is held between **50 ms** and **60000 ms** — a zero delay would
+  schedule retries with no spacing (a hot loop allocating an `AsyncClient` per
+  scheduler tick); the ceiling keeps `retryDelayMs * 8` clear of `uint32_t`
+  overflow.
+
+Everything else passes through untouched, including zeros, which are meaningful:
+`maxRetries = 0` means "do not retry at all", `stabilizationDelayMs = 0` means
+"connect immediately on IP acquisition", `exhaustionReconnectDelayMs = 0` means
+"reconnect WiFi immediately", and `failureBlockDurationMs = 0` means "never
+blocklist a failed peer". Use `getTcpRetryConfig()` to read back what actually
+took effect.
+
+> [!WARNING]
+> The defaults exist for a reason: painlessMesh 1.9.x deliberately *raised*
+> these values (retries 3 → 5, base delay 500 ms → 1000 ms) to fix real-world
+> mesh instability. Tuning them down reintroduces the problems that change
+> fixed — connection churn, rapid reconnect loops, and network congestion.
+> In particular, keep `failureBlockDurationMs` greater than
+> `(sum of retry backoffs) + exhaustionReconnectDelayMs`, or a dead peer will
+> leave the blocklist before the node has finished failing over and be
+> re-selected immediately.
+
 ## Message Configuration
 
 ### Package Registration

--- a/examples/tcpRetryConfig/README.md
+++ b/examples/tcpRetryConfig/README.md
@@ -1,0 +1,110 @@
+# tcpRetryConfig
+
+Tuning painlessMesh's TCP connection retry behaviour with
+`setTcpRetryConfig()` (issue
+[#378](https://github.com/Alteriom/painlessMesh/issues/378)).
+
+## What this controls
+
+When a node acquires an IP and tries to open its TCP connection to the mesh,
+that connection can fail — the parent's TCP server may not be ready yet, the
+network stack may still be settling, or several nodes may be connecting at
+once. painlessMesh retries with exponential backoff before giving up and
+falling back to a full WiFi reconnect.
+
+Five parameters describe that behaviour:
+
+| Field | Default | Meaning |
+|---|---|---|
+| `maxRetries` | 5 | TCP connect attempts after the first before giving up |
+| `retryDelayMs` | 1000 | Base delay between retries; scaled 1x, 2x, 4x, 8x, 8x |
+| `stabilizationDelayMs` | 500 | Wait after IP acquisition before the first attempt |
+| `exhaustionReconnectDelayMs` | 10000 | Wait before the WiFi reconnect that follows exhaustion |
+| `failureBlockDurationMs` | 60000 | How long a failed peer is skipped during AP selection |
+
+With the defaults, a node that cannot reach its parent spends
+1 + 2 + 4 + 8 + 8 = **23 s** retrying, then waits another **10 s** before
+reconnecting WiFi, and will not re-select that same peer for **60 s**.
+
+## Profiles in this sketch
+
+Switch with `#define ACTIVE_PROFILE`.
+
+| | `PROFILE_REALTIME` | default | `PROFILE_RELIABLE` | `PROFILE_BATTERY` |
+|---|---|---|---|---|
+| `maxRetries` | 1 | 5 | 10 | 2 |
+| `retryDelayMs` | 200 | 1000 | 2000 | 3000 |
+| `stabilizationDelayMs` | 100 | 500 | 1000 | 500 |
+| `exhaustionReconnectDelayMs` | 1000 | 10000 | 30000 | 60000 |
+| `failureBlockDurationMs` | 5000 | 60000 | 180000 | 300000 |
+| worst-case retry time | 0.2 s | 23 s | 126 s | 9 s |
+| full failure cycle | 1.2 s | 33 s | 156 s | 69 s |
+
+- **`PROFILE_REALTIME`** — real-time sensor and LED meshes, the use case from
+  [discussion #368](https://github.com/Alteriom/painlessMesh/discussions/368).
+  A node stuck in a 23 s backoff is worse than one that drops and re-scans, so
+  fail fast and move on.
+- **`PROFILE_RELIABLE`** — industrial meshes where getting connected matters
+  more than how long it takes. `maxRetries = 10` is the maximum the library
+  accepts.
+- **`PROFILE_BATTERY`** — every retry is radio-on time. Few attempts, spaced
+  widely, and a long blocklist so the node stops waking up for a peer that is
+  known to be down.
+
+## Clamping
+
+`setTcpRetryConfig()` coerces the two values that can render a node unusable:
+
+- `maxRetries` is capped at **10**. Each retry allocates an `AsyncClient` and
+  schedules a task, so an unbounded value is a heap and recursion-depth hazard
+  on ESP8266.
+- `retryDelayMs` is held between **50 ms** and **60000 ms**. A zero delay would
+  schedule retries with no spacing — a hot loop allocating an `AsyncClient`
+  every scheduler tick. The ceiling keeps `retryDelayMs * 8` clear of `uint32_t`
+  overflow.
+
+Everything else passes through untouched, including zeros, which are
+meaningful:
+
+- `maxRetries = 0` — do not retry at all; fall straight back to a WiFi
+  reconnect on the first TCP error.
+- `stabilizationDelayMs = 0` — attempt the TCP connection immediately on IP
+  acquisition.
+- `exhaustionReconnectDelayMs = 0` — reconnect WiFi immediately after
+  exhaustion.
+- `failureBlockDurationMs = 0` — never blocklist a failed peer.
+
+Call `getTcpRetryConfig()` after setting to see what actually took effect; the
+sketch prints this at startup.
+
+## The defaults exist for a reason
+
+painlessMesh 1.9.x deliberately *raised* these values (retries 3 → 5, base
+delay 500 ms → 1000 ms) to fix real-world mesh instability. Tuning them back
+down reintroduces the problems that change fixed. Symptoms of an over-aggressive
+profile:
+
+- **Connection churn** — nodes repeatedly connect and drop. `maxRetries` is too
+  low for how long your parent actually takes to be ready; raise it or raise
+  `stabilizationDelayMs`.
+- **Rapid reconnect loops / network congestion** — a node hammers a parent whose
+  TCP server is down. `exhaustionReconnectDelayMs` is too short.
+- **The same dead peer is picked over and over** — `failureBlockDurationMs` is
+  shorter than one full retry-plus-reconnect cycle, so the peer comes off the
+  blocklist before the node has finished failing over. Keep
+  `failureBlockDurationMs` greater than
+  `(sum of retry backoffs) + exhaustionReconnectDelayMs`. All three profiles
+  above satisfy this; `catch_tcp_blocklist.cpp` pins it as a test.
+
+Change one parameter at a time and watch the serial log with
+`mesh.setDebugMsgTypes(ERROR | STARTUP | CONNECTION)`.
+
+## Building
+
+```bash
+# PlatformIO
+pio run -e esp32     # or -e esp8266
+
+# Arduino CLI
+arduino-cli compile --fqbn esp32:esp32:esp32 examples/tcpRetryConfig/tcpRetryConfig.ino
+```

--- a/examples/tcpRetryConfig/platformio.ini
+++ b/examples/tcpRetryConfig/platformio.ini
@@ -1,0 +1,26 @@
+[platformio]
+src_dir = .
+
+[env]
+lib_deps =
+    bblanchon/ArduinoJson
+    arkhipenko/TaskScheduler
+
+lib_ldf_mode = deep+
+[env:esp8266]
+platform = espressif8266
+board = nodemcuv2
+framework = arduino
+lib_extra_dirs = ../../
+lib_deps =
+    ${env.lib_deps}  ; Inherit common dependencies
+    esp32async/ESPAsyncTCP@^2.0.0  ; Only for ESP8266
+
+[env:esp32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_extra_dirs = ../../
+lib_deps =
+    ${env.lib_deps}  ; Inherit common dependencies
+    esp32async/AsyncTCP

--- a/examples/tcpRetryConfig/tcpRetryConfig.ino
+++ b/examples/tcpRetryConfig/tcpRetryConfig.ino
@@ -1,0 +1,154 @@
+//************************************************************
+// Tuning the TCP connection retry behaviour (issue #378)
+//
+// painlessMesh retries a failed TCP connection with exponential backoff
+// before giving up and falling back to a full WiFi reconnect. The defaults
+// (5 retries, 1s base delay -> 1s, 2s, 4s, 8s, 8s) are tuned for general
+// purpose meshes and deliberately favour reliability over speed.
+//
+// setTcpRetryConfig() lets you pick a different trade-off. Three ready-made
+// profiles are shown below; switch between them with ACTIVE_PROFILE.
+//
+// Read examples/tcpRetryConfig/README.md before changing these values - the
+// defaults exist because 1.9.x raised them to fix real mesh instability.
+//************************************************************
+#include <painlessMesh.h>
+
+#define   MESH_SSID       "whateverYouLike"
+#define   MESH_PASSWORD   "somethingSneaky"
+#define   MESH_PORT       5555
+
+// ---------------------------------------------------------------------------
+// Profiles
+// ---------------------------------------------------------------------------
+#define PROFILE_REALTIME  1   // low latency: fail fast, reconnect fast
+#define PROFILE_RELIABLE  2   // industrial: many retries, long backoff
+#define PROFILE_BATTERY   3   // conserve power: few retries, long block
+
+// >>> Change this line to try a different profile <<<
+#define ACTIVE_PROFILE    PROFILE_REALTIME
+
+// Prototypes
+void sendMessage();
+void receivedCallback(uint32_t from, String &msg);
+void newConnectionCallback(uint32_t nodeId);
+void droppedConnectionCallback(uint32_t nodeId);
+
+Scheduler     userScheduler;
+painlessMesh  mesh;
+
+Task taskSendMessage(TASK_SECOND * 5, TASK_FOREVER, &sendMessage);
+
+// Build the retry configuration for the selected profile.
+painlessmesh::tcp::TcpRetryConfig buildRetryConfig() {
+  painlessmesh::tcp::TcpRetryConfig cfg;  // starts at the library defaults
+
+#if ACTIVE_PROFILE == PROFILE_REALTIME
+  // Real-time sensor / LED meshes: a stalled node is worse than a dropped
+  // one. Give up on the TCP handshake almost immediately and go straight
+  // back to scanning for another parent.
+  cfg.maxRetries = 1;                    // default 5
+  cfg.retryDelayMs = 200;                // default 1000
+  cfg.stabilizationDelayMs = 100;        // default 500
+  cfg.exhaustionReconnectDelayMs = 1000; // default 10000
+  cfg.failureBlockDurationMs = 5000;     // default 60000
+
+#elif ACTIVE_PROFILE == PROFILE_RELIABLE
+  // Industrial / high-reliability meshes: connectivity matters more than
+  // how long it takes to get there. Retry patiently and keep a failed peer
+  // out of the running for a good while.
+  cfg.maxRetries = 10;                     // default 5 (this is the maximum)
+  cfg.retryDelayMs = 2000;                 // default 1000
+  cfg.stabilizationDelayMs = 1000;         // default 500
+  cfg.exhaustionReconnectDelayMs = 30000;  // default 10000
+  // Must exceed one full failure cycle (126s of retries + 30s reconnect),
+  // otherwise a dead peer leaves the blocklist before we finished failing
+  // over and gets re-selected immediately.
+  cfg.failureBlockDurationMs = 180000;     // default 60000
+
+#elif ACTIVE_PROFILE == PROFILE_BATTERY
+  // Battery-powered nodes: every retry is radio time. Few attempts, spaced
+  // widely, and a long blocklist so we do not keep waking up for a peer
+  // that is known to be down.
+  cfg.maxRetries = 2;                      // default 5
+  cfg.retryDelayMs = 3000;                 // default 1000
+  cfg.stabilizationDelayMs = 500;          // default 500
+  cfg.exhaustionReconnectDelayMs = 60000;  // default 10000
+  cfg.failureBlockDurationMs = 300000;     // default 60000
+
+#else
+  #error "ACTIVE_PROFILE must be one of PROFILE_REALTIME, PROFILE_RELIABLE, PROFILE_BATTERY"
+#endif
+
+  return cfg;
+}
+
+void setup() {
+  Serial.begin(115200);
+
+  mesh.setDebugMsgTypes(ERROR | STARTUP | CONNECTION);
+
+  // Apply the retry configuration BEFORE init() so the very first connection
+  // attempt already uses it.
+  mesh.setTcpRetryConfig(buildRetryConfig());
+
+  mesh.init(MESH_SSID, MESH_PASSWORD, &userScheduler, MESH_PORT);
+
+  // Read the configuration back. Values outside safe operating bounds are
+  // clamped by the setter, so this prints what is actually in effect - not
+  // necessarily what was requested.
+  painlessmesh::tcp::TcpRetryConfig active = mesh.getTcpRetryConfig();
+  Serial.println();
+  Serial.println(F("Effective TCP retry configuration:"));
+  Serial.printf("  maxRetries                 = %u\n",
+                (unsigned)active.maxRetries);
+  Serial.printf("  retryDelayMs               = %u\n",
+                (unsigned)active.retryDelayMs);
+  Serial.printf("  stabilizationDelayMs       = %u\n",
+                (unsigned)active.stabilizationDelayMs);
+  Serial.printf("  exhaustionReconnectDelayMs = %u\n",
+                (unsigned)active.exhaustionReconnectDelayMs);
+  Serial.printf("  failureBlockDurationMs     = %u\n",
+                (unsigned)active.failureBlockDurationMs);
+
+  // Worst-case time spent retrying before falling back to a WiFi reconnect.
+  uint32_t worstCase = 0;
+  for (uint8_t i = 0; i < active.maxRetries; ++i) {
+    worstCase += painlessmesh::tcp::retryBackoffDelay(active, i);
+  }
+  Serial.printf("  -> worst-case retry time   = %u ms\n", (unsigned)worstCase);
+  Serial.printf("  -> plus reconnect delay    = %u ms\n",
+                (unsigned)(worstCase + active.exhaustionReconnectDelayMs));
+  Serial.println();
+
+  mesh.onReceive(&receivedCallback);
+  mesh.onNewConnection(&newConnectionCallback);
+  mesh.onDroppedConnection(&droppedConnectionCallback);
+
+  userScheduler.addTask(taskSendMessage);
+  taskSendMessage.enable();
+}
+
+void loop() {
+  mesh.update();
+}
+
+void sendMessage() {
+  String msg = "Hello from node ";
+  msg += mesh.getNodeId();
+  mesh.sendBroadcast(msg);
+}
+
+void receivedCallback(uint32_t from, String &msg) {
+  Serial.printf("tcpRetryConfig: Received from %u msg=%s\n", from, msg.c_str());
+}
+
+void newConnectionCallback(uint32_t nodeId) {
+  Serial.printf("--> Connected to node %u\n", nodeId);
+}
+
+void droppedConnectionCallback(uint32_t nodeId) {
+  // With an aggressive profile you should expect to see this more often -
+  // and to see the reconnect that follows it happen much sooner.
+  Serial.printf("--> Dropped connection to node %u\n", nodeId);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -4,6 +4,7 @@
 painlessMesh	KEYWORD1
 Scheduler	KEYWORD1
 Task	KEYWORD1
+TcpRetryConfig	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
 init	KEYWORD2
@@ -18,6 +19,8 @@ getNodeList	KEYWORD2
 getNodeId	KEYWORD2
 getNodeTime	KEYWORD2
 setDebugMsgTypes	KEYWORD2
+setTcpRetryConfig	KEYWORD2
+getTcpRetryConfig	KEYWORD2
 subConnectionJson	KEYWORD2
 asNodeTree	KEYWORD2
 

--- a/src/arduino/wifi.hpp
+++ b/src/arduino/wifi.hpp
@@ -817,8 +817,9 @@ class Mesh : public painlessmesh::Mesh<Connection> {
    * TCP Connection Retry:
    * The TCP connection now includes automatic retry with exponential backoff.
    * If the initial connection fails (error -14 ERR_CONN or other errors),
-   * the system will retry up to TCP_CONNECT_MAX_RETRIES times before
-   * triggering a full WiFi reconnection cycle. This helps handle:
+   * the system will retry up to the configured maxRetries times before
+   * triggering a full WiFi reconnection cycle (see setTcpRetryConfig()).
+   * This helps handle:
    * - Timing issues where TCP server is not ready immediately
    * - Network stack stabilization after IP acquisition
    * - Transient network conditions
@@ -842,8 +843,11 @@ class Mesh : public painlessmesh::Mesh<Connection> {
       // This helps prevent error -14 (ERR_CONN) by allowing the network stack
       // and TCP server to be fully ready. The delay is added via task scheduler
       // to avoid blocking the event loop.
+      // The delay is read at schedule time, so calling setTcpRetryConfig()
+      // while a connect is already pending affects the next attempt, not the
+      // in-flight one.
       this->addTask(
-          painlessmesh::tcp::TCP_CONNECT_STABILIZATION_DELAY_MS, TASK_ONCE,
+          this->getTcpRetryConfig().stabilizationDelayMs, TASK_ONCE,
           [this, targetIP, targetPort]() {
             // Verify WiFi is still connected after the delay
             if (WiFi.status() != WL_CONNECTED || !WiFi.localIP()) {

--- a/src/painlessmesh/mesh.hpp
+++ b/src/painlessmesh/mesh.hpp
@@ -1395,6 +1395,32 @@ class Mesh : public ntp::MeshTime, public plugin::PackageHandler<T> {
   }
 
   /**
+   * Configure TCP connection retry behaviour
+   *
+   * Lets latency-sensitive, high-reliability or battery-powered deployments
+   * pick their own retry envelope. Values outside safe operating bounds are
+   * clamped - see painlessmesh::tcp::clampTcpRetryConfig(). Read the applied
+   * (post-clamp) values back with getTcpRetryConfig().
+   *
+   * The defaults reproduce the previous hardcoded behaviour exactly, so
+   * existing sketches that never call this see no change.
+   *
+   * @param config Retry parameters to apply
+   */
+  void setTcpRetryConfig(const painlessmesh::tcp::TcpRetryConfig &config) {
+    tcpRetryConfig = painlessmesh::tcp::clampTcpRetryConfig(config);
+  }
+
+  /**
+   * Get the active TCP retry configuration
+   *
+   * @return The configuration currently in effect, after clamping
+   */
+  painlessmesh::tcp::TcpRetryConfig getTcpRetryConfig() const {
+    return tcpRetryConfig;
+  }
+
+  /**
    * Get number of pending Internet requests
    *
    * @return Number of requests waiting for acknowledgment
@@ -3261,6 +3287,13 @@ class Mesh : public ntp::MeshTime, public plugin::PackageHandler<T> {
   uint8_t internetRetryCount = 3;            // Default 3 retries
   uint32_t internetRetryDelay = 1000;        // Default 1 second base delay
   bool sendToInternetEnabled = false;
+
+  // TCP connect retry parameters, see setTcpRetryConfig().
+  // Public because tcp::connect<Connection, wifi::Mesh> reads it but is NOT a
+  // friend: the friend declaration below names connect<T, Mesh<T>>, whereas
+  // wifi::Mesh::tcpConnect() instantiates connect<Connection, wifi::Mesh> - a
+  // different specialisation. Same reason as the public: sections above.
+  painlessmesh::tcp::TcpRetryConfig tcpRetryConfig;
 
   friend T;
   friend void onDataCb(void *, AsyncClient *, void *, size_t);

--- a/src/painlessmesh/tcp.hpp
+++ b/src/painlessmesh/tcp.hpp
@@ -30,6 +30,84 @@ static const uint32_t TCP_EXHAUSTION_RECONNECT_DELAY_MS = 10000; // 10 seconds b
 // This prevents repeatedly trying to connect to nodes with unresponsive TCP servers
 static const uint32_t TCP_FAILURE_BLOCK_DURATION_MS = 60000;
 
+// Safe operating bounds applied by clampTcpRetryConfig().
+// Each retry allocates a new AsyncClient and schedules a task, so an unbounded
+// maxRetries is a heap and recursion-depth hazard on ESP8266. A zero retry
+// delay would schedule retry tasks with no spacing, i.e. a hot loop allocating
+// an AsyncClient per scheduler tick.
+static const uint8_t TCP_RETRY_MAX_RETRIES_LIMIT = 10;
+static const uint32_t TCP_RETRY_MIN_DELAY_MS = 50;
+static const uint32_t TCP_RETRY_MAX_DELAY_MS = 60000;
+
+/**
+ * User-tunable TCP connection retry parameters
+ *
+ * One instance is stored per mesh (painlessmesh::Mesh), configured through
+ * Mesh::setTcpRetryConfig(). The member defaults are spelled as the legacy
+ * constants above rather than as literals, so the "defaults match the previous
+ * hardcoded behaviour exactly" guarantee is enforced by the compiler and cannot
+ * silently drift.
+ *
+ * NOTE: this deliberately lives on the mesh instance rather than at namespace
+ * scope. A mutable namespace-scope instance in this header would give every
+ * translation unit its own private copy, so a sketch that configured the mesh
+ * in one TU and connected from another would silently fall back to defaults
+ * with no diagnostic.
+ */
+struct TcpRetryConfig {
+  /// Max TCP connect retry attempts before falling back to a WiFi reconnect
+  uint8_t maxRetries = TCP_CONNECT_MAX_RETRIES;
+  /// Base delay between retry attempts (ms), scaled by exponential backoff
+  uint32_t retryDelayMs = TCP_CONNECT_RETRY_DELAY_MS;
+  /// Delay after IP acquisition before the TCP connect is attempted (ms)
+  uint32_t stabilizationDelayMs = TCP_CONNECT_STABILIZATION_DELAY_MS;
+  /// Delay before the WiFi reconnect that follows retry exhaustion (ms)
+  uint32_t exhaustionReconnectDelayMs = TCP_EXHAUSTION_RECONNECT_DELAY_MS;
+  /// Duration a node is blocklisted after retry exhaustion (ms, 0 = never)
+  uint32_t failureBlockDurationMs = TCP_FAILURE_BLOCK_DURATION_MS;
+};
+
+/**
+ * Delay before retry attempt number `retryCount`
+ *
+ * Exponential backoff with the multiplier capped at 8, giving the default
+ * sequence 1s, 2s, 4s, 8s, 8s. Capping prevents excessive delays and keeps the
+ * product clear of uint32_t overflow.
+ *
+ * @param cfg Active retry configuration
+ * @param retryCount Zero-based retry attempt number
+ * @return Delay in milliseconds
+ */
+inline uint32_t retryBackoffDelay(const TcpRetryConfig &cfg,
+                                  uint8_t retryCount) {
+  uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
+  return cfg.retryDelayMs * backoffMultiplier;
+}
+
+/**
+ * Coerce a retry configuration into safe operating bounds
+ *
+ * Only the two values that can render a node unusable are clamped:
+ * maxRetries (heap/recursion pressure) and retryDelayMs (hot-loop floor and
+ * overflow ceiling). maxRetries == 0 is explicitly allowed - it means "fall
+ * back to a WiFi reconnect on the first TCP error", which is the whole point
+ * of the low-latency profile. stabilizationDelayMs, exhaustionReconnectDelayMs
+ * and failureBlockDurationMs are left alone because 0 is meaningful for each
+ * (skip stabilization / reconnect immediately / never blocklist).
+ *
+ * @param cfg Configuration to clamp (taken by value, returned clamped)
+ * @return The clamped configuration
+ */
+inline TcpRetryConfig clampTcpRetryConfig(TcpRetryConfig cfg) {
+  if (cfg.maxRetries > TCP_RETRY_MAX_RETRIES_LIMIT)
+    cfg.maxRetries = TCP_RETRY_MAX_RETRIES_LIMIT;
+  if (cfg.retryDelayMs < TCP_RETRY_MIN_DELAY_MS)
+    cfg.retryDelayMs = TCP_RETRY_MIN_DELAY_MS;
+  if (cfg.retryDelayMs > TCP_RETRY_MAX_DELAY_MS)
+    cfg.retryDelayMs = TCP_RETRY_MAX_DELAY_MS;
+  return cfg;
+}
+
 inline uint32_t encodeNodeId(const uint8_t *hwaddr) {
   using namespace painlessmesh::logger;
   Log(GENERAL, "encodeNodeId():\n");
@@ -93,8 +171,9 @@ void initServer(AsyncServer &server, M &mesh) {
  * 
  * This function attempts to connect to the mesh network via TCP.
  * If the connection fails (error -14 ERR_CONN or other errors), it will
- * retry up to TCP_CONNECT_MAX_RETRIES times before triggering a full
- * WiFi reconnection cycle.
+ * retry up to the configured maxRetries times before triggering a full
+ * WiFi reconnection cycle. See Mesh::setTcpRetryConfig() to tune the retry
+ * envelope; the defaults reproduce the historic hardcoded behaviour.
  * 
  * The retry mechanism helps handle timing issues where:
  * - The TCP server may not be immediately ready after AP initialization
@@ -117,10 +196,19 @@ template <class T, class M>
 void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh, 
              uint8_t retryCount = 0) {
   using namespace logger;
-  
+
+  // Snapshot the retry configuration once, before any lambda is built. The
+  // onError lambda outlives this stack frame, so it captures this snapshot by
+  // value rather than reading mesh's member later: a user callback could
+  // otherwise mutate the config between the connect attempt and the error,
+  // tearing the backoff schedule mid-sequence. Each retry re-enters connect()
+  // and re-snapshots, so a config change still takes effect on the next
+  // attempt.
+  const TcpRetryConfig cfg = mesh.getTcpRetryConfig();
+
   Log(CONNECTION, "tcp::connect(): Attempting connection to port %d (attempt %d/%d)\n",
-      port, retryCount + 1, TCP_CONNECT_MAX_RETRIES + 1);
-  
+      port, retryCount + 1, cfg.maxRetries + 1);
+
   // Guard shared between onError and onConnect: under normal conditions a
   // TCP connection attempt leads to only ONE of the two outcomes. But if
   // WiFi drops right as the TCP handshake completes, AsyncTCP can queue
@@ -137,7 +225,7 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
   
   // Store retry count and connection parameters for the error handler
   // We need to capture these by value since they're used in the lambda
-  client.onError([&mesh, ip, port, retryCount, claimed](void *, AsyncClient *client, int8_t err) {
+  client.onError([&mesh, ip, port, retryCount, claimed, cfg](void *, AsyncClient *client, int8_t err) {
     if (*claimed) {
       // onConnect has already claimed this client (the connection actually
       // succeeded, and it's already been wrapped in a BufferedConnection
@@ -149,8 +237,8 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
     }
     *claimed = true;
     if (mesh.semaphoreTake()) {
-      Log(CONNECTION, "tcp_err(): error trying to connect %d (attempt %d/%d)\n", 
-          err, retryCount + 1, TCP_CONNECT_MAX_RETRIES + 1);
+      Log(CONNECTION, "tcp_err(): error trying to connect %d (attempt %d/%d)\n",
+          err, retryCount + 1, cfg.maxRetries + 1);
       
       // Check if we have retries left - retry logic only works on real hardware
       // In test environment (PAINLESSMESH_BOOST), fall through to dropped connection
@@ -158,27 +246,21 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
       (void)ip;
       (void)port;
 #if !defined(PAINLESSMESH_BOOST) && (defined(ESP32) || defined(ESP8266))
-      if (retryCount < TCP_CONNECT_MAX_RETRIES) {
-        // Calculate delay with exponential backoff: base_delay * 2^retryCount
-        // This gives increasing time between retries as failures accumulate:
-        // - retryCount=0: 1000ms * 1 = 1s
-        // - retryCount=1: 1000ms * 2 = 2s
-        // - retryCount=2: 1000ms * 4 = 4s
-        // - retryCount=3: 1000ms * 8 = 8s (capped at 8)
-        // - retryCount=4: 1000ms * 8 = 8s (capped at 8)
-        // Cap multiplier at 8 to prevent excessive delays
-        uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
-        uint32_t retryDelay = TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
-        
-        Log(CONNECTION, "tcp_err(): Scheduling retry in %u ms (backoff x%d)\n", 
-            retryDelay, backoffMultiplier);
+      if (retryCount < cfg.maxRetries) {
+        // Delay grows with exponential backoff, multiplier capped at 8.
+        // With the default 1000ms base that is: 1s, 2s, 4s, 8s, 8s.
+        uint32_t retryDelay = retryBackoffDelay(cfg, retryCount);
+
+        Log(CONNECTION, "tcp_err(): Scheduling retry in %u ms\n", retryDelay);
         
         // Schedule a retry after a delay using the mesh's task scheduler
         // Note: &mesh is captured by reference because:
         // 1. Mesh is a singleton that lives for the program's lifetime
         // 2. The task scheduler belongs to the mesh, so mesh is always valid when task runs
         // 3. Copying the mesh object is not possible/allowed
-        // Recursion depth is strictly bounded by TCP_CONNECT_MAX_RETRIES (default: 5)
+        // Recursion depth is strictly bounded by cfg.maxRetries (default 5),
+        // which clampTcpRetryConfig() never lets exceed
+        // TCP_RETRY_MAX_RETRIES_LIMIT (10).
         mesh.addTask([&mesh, ip, port, retryCount]() {
           Log(CONNECTION, "tcp_err(): Retrying TCP connection...\n");
           
@@ -202,7 +284,7 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
       // Adding a significant delay before reconnection prevents rapid reconnection loops
       // when the TCP server is persistently unavailable or overloaded
       Log(CONNECTION, "tcp_err(): All %d retries exhausted for IP %s\n",
-          TCP_CONNECT_MAX_RETRIES + 1, ip.toString().c_str());
+          cfg.maxRetries + 1, ip.toString().c_str());
       
       // Block this node temporarily to prevent immediate reconnection to the same unresponsive node
       // This helps when the bridge's TCP server is down but WiFi AP is still running
@@ -210,15 +292,19 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
       #if !defined(PAINLESSMESH_BOOST)
       // Try to decode nodeId from IP and block it
       // Only works for mesh IPs (format: 10.x.x.1)
+      // A failureBlockDurationMs of 0 is an explicit "never blocklist" opt-out.
+      // Passing it through would set blockUntil = millis() + 0, which
+      // isNodeBlocked() reads as already expired - so the entry would do
+      // nothing except linger in the blocklist until cleanup sweeps it.
       uint32_t failedNodeId = decodeNodeIdFromIP(ip);
-      if (failedNodeId != 0) {
+      if (failedNodeId != 0 && cfg.failureBlockDurationMs > 0) {
         // Note: This requires M to be wifi::Mesh which has blockNodeAfterTCPFailure
-        mesh.blockNodeAfterTCPFailure(ip, TCP_FAILURE_BLOCK_DURATION_MS);
+        mesh.blockNodeAfterTCPFailure(ip, cfg.failureBlockDurationMs);
       }
       #endif
-      
+
       Log(CONNECTION, "tcp_err(): Scheduling WiFi reconnection in %u ms\n",
-          TCP_EXHAUSTION_RECONNECT_DELAY_MS);
+          cfg.exhaustionReconnectDelayMs);
       
       // Defer deletion of the failed AsyncClient to prevent heap corruption
       // Use the centralized deletion scheduler to ensure proper spacing between deletions
@@ -232,7 +318,7 @@ void connect(AsyncClient &client, IPAddress ip, uint16_t port, M &mesh,
       mesh.addTask([&mesh]() {
         Log(CONNECTION, "tcp_err(): Executing delayed WiFi reconnection after retry exhaustion\n");
         mesh.droppedConnectionCallbacks.execute(0, true);
-      }, TCP_EXHAUSTION_RECONNECT_DELAY_MS);
+      }, cfg.exhaustionReconnectDelayMs);
       mesh.semaphoreGive();
     }
   });

--- a/test/catch/catch_tcp_blocklist.cpp
+++ b/test/catch/catch_tcp_blocklist.cpp
@@ -7,6 +7,14 @@
 WiFiClass WiFi;
 ESPClass ESP;
 
+// Log must be declared before tcp.hpp: the non-template helpers in that
+// header call it, so it has to be visible at their point of definition.
+#include "painlessmesh/logger.hpp"
+
+painlessmesh::logger::LogClass Log;
+
+#include "painlessmesh/tcp.hpp"
+
 // Test the TCP failure blocklist mechanism
 // This validates the fix for the infinite connection retry loop issue
 
@@ -152,29 +160,103 @@ SCENARIO("Blocklist correctly identifies mesh IP addresses",
 
 SCENARIO("TCP exhaustion delay provides adequate recovery time",
          "[tcp][exhaustion][delay]") {
-  GIVEN("TCP connection retry exhaustion parameters") {
-    const uint32_t TCP_EXHAUSTION_RECONNECT_DELAY_MS = 10000;  // 10 seconds
-    const uint32_t TCP_FAILURE_BLOCK_DURATION_MS = 60000;       // 60 seconds
-    
+  GIVEN("The default TCP retry configuration") {
+    // Read the real shipped defaults rather than re-declaring them locally, so
+    // the anti-thrash invariant below is checked against values that actually
+    // ship.
+    painlessmesh::tcp::TcpRetryConfig cfg;
+
     WHEN("All retries are exhausted") {
-      // After 6 failed attempts with exponential backoff: 1s + 2s + 4s + 8s + 8s = 23s
-      uint32_t totalRetryTime = 23000;
-      
+      // Total backoff across all retries: 1s + 2s + 4s + 8s + 8s = 23s
+      uint32_t totalRetryTime = 0;
+      for (uint8_t retryCount = 0; retryCount < cfg.maxRetries; ++retryCount) {
+        totalRetryTime += painlessmesh::tcp::retryBackoffDelay(cfg, retryCount);
+      }
+      REQUIRE(totalRetryTime == 23000);
+
       THEN("WiFi reconnection delay should prevent rapid loops") {
         // The 10 second delay before reconnection gives the TCP server time to recover
-        REQUIRE(TCP_EXHAUSTION_RECONNECT_DELAY_MS >= 10000);
+        REQUIRE(cfg.exhaustionReconnectDelayMs >= 10000);
       }
-      
+
       THEN("Block duration should exceed total retry time plus reconnection delay") {
         // Total time before next attempt on same node:
         // Retry time (23s) + Reconnection delay (10s) = 33s
         // Block duration (60s) ensures node won't be retried during this cycle
-        uint32_t minTimeBetweenAttempts = totalRetryTime + TCP_EXHAUSTION_RECONNECT_DELAY_MS;
-        REQUIRE(TCP_FAILURE_BLOCK_DURATION_MS > minTimeBetweenAttempts);
-        
+        uint32_t minTimeBetweenAttempts =
+            totalRetryTime + cfg.exhaustionReconnectDelayMs;
+        REQUIRE(cfg.failureBlockDurationMs > minTimeBetweenAttempts);
+
         // This prevents: Scan -> Find blocked node -> Skip -> Scan -> Find again too soon
-        REQUIRE(TCP_FAILURE_BLOCK_DURATION_MS >= 60000);  // At least 60 seconds
+        REQUIRE(cfg.failureBlockDurationMs >= 60000);  // At least 60 seconds
       }
+    }
+  }
+}
+
+namespace {
+/// Total time spent retrying before the fallback WiFi reconnect is scheduled.
+uint32_t totalRetryTime(const painlessmesh::tcp::TcpRetryConfig &cfg) {
+  uint32_t total = 0;
+  for (uint8_t retryCount = 0; retryCount < cfg.maxRetries; ++retryCount) {
+    total += painlessmesh::tcp::retryBackoffDelay(cfg, retryCount);
+  }
+  return total;
+}
+}  // namespace
+
+SCENARIO("Every documented tuning profile preserves the anti-thrash invariant",
+         "[tcp][exhaustion][delay][profiles]") {
+  // failureBlockDurationMs must outlast one full failure cycle
+  // (all retry backoffs + the exhaustion reconnect delay). Otherwise a dead
+  // peer leaves the blocklist before the node has finished failing over and
+  // is immediately re-selected - exactly the thrash the blocklist exists to
+  // prevent.
+  //
+  // This caught a real bug while writing the profiles: the high-reliability
+  // profile originally paired 126s of retries + 30s reconnect with a 120s
+  // block, which silently violated the invariant. Keep this test in sync with
+  // examples/tcpRetryConfig and docsify-site/api/configuration.md.
+  GIVEN("The low-latency profile") {
+    painlessmesh::tcp::TcpRetryConfig cfg;
+    cfg.maxRetries = 1;
+    cfg.retryDelayMs = 200;
+    cfg.exhaustionReconnectDelayMs = 1000;
+    cfg.failureBlockDurationMs = 5000;
+
+    THEN("The failure cycle is far shorter than the default") {
+      uint32_t cycleTime = totalRetryTime(cfg) + cfg.exhaustionReconnectDelayMs;
+      REQUIRE(cycleTime == 1200);  // vs 33000 on defaults
+      REQUIRE(cfg.failureBlockDurationMs > cycleTime);
+    }
+  }
+
+  GIVEN("The high-reliability profile") {
+    painlessmesh::tcp::TcpRetryConfig cfg;
+    cfg.maxRetries = 10;
+    cfg.retryDelayMs = 2000;
+    cfg.exhaustionReconnectDelayMs = 30000;
+    cfg.failureBlockDurationMs = 180000;
+
+    THEN("The block duration outlasts the long retry cycle") {
+      REQUIRE(totalRetryTime(cfg) == 126000);
+      uint32_t cycleTime = totalRetryTime(cfg) + cfg.exhaustionReconnectDelayMs;
+      REQUIRE(cycleTime == 156000);
+      REQUIRE(cfg.failureBlockDurationMs > cycleTime);
+    }
+  }
+
+  GIVEN("The battery-saver profile") {
+    painlessmesh::tcp::TcpRetryConfig cfg;
+    cfg.maxRetries = 2;
+    cfg.retryDelayMs = 3000;
+    cfg.exhaustionReconnectDelayMs = 60000;
+    cfg.failureBlockDurationMs = 300000;
+
+    THEN("The block duration outlasts the failure cycle") {
+      uint32_t cycleTime = totalRetryTime(cfg) + cfg.exhaustionReconnectDelayMs;
+      REQUIRE(cycleTime == 69000);
+      REQUIRE(cfg.failureBlockDurationMs > cycleTime);
     }
   }
 }

--- a/test/catch/catch_tcp_retry.cpp
+++ b/test/catch/catch_tcp_retry.cpp
@@ -7,125 +7,114 @@
 WiFiClass WiFi;
 ESPClass ESP;
 
-// Test the TCP retry configuration values and backoff formula
-// Note: We re-declare the constants here to test them independently
-// because including tcp.hpp requires complex template resolution
+// Log must be declared before tcp.hpp: the non-template helpers in that
+// header call it, so it has to be visible at their point of definition.
+#include "painlessmesh/logger.hpp"
 
-namespace tcp_test {
-// These should match the values in painlessmesh/tcp.hpp
-// TCP_CLIENT_CLEANUP_DELAY_MS and TCP_CLIENT_DELETION_SPACING_MS are defined in painlessmesh/connection.hpp
-static const uint8_t TCP_CONNECT_MAX_RETRIES = 5;
-static const uint32_t TCP_CONNECT_RETRY_DELAY_MS = 1000;
-static const uint32_t TCP_CONNECT_STABILIZATION_DELAY_MS = 500;
-static const uint32_t TCP_CLIENT_CLEANUP_DELAY_MS = 1000;  // Base delay before deleting AsyncClient
-static const uint32_t TCP_CLIENT_DELETION_SPACING_MS = 1000; // Spacing between consecutive deletions
-static const uint32_t TCP_EXHAUSTION_RECONNECT_DELAY_MS = 10000;
-}  // namespace tcp_test
+using namespace painlessmesh;
 
-SCENARIO("TCP connection retry constants are configured correctly",
+logger::LogClass Log;
+
+#include "painlessmesh/connection.hpp"
+#include "painlessmesh/tcp.hpp"
+
+// These tests exercise the real shipped TcpRetryConfig defaults and the real
+// tcp::retryBackoffDelay() helper rather than re-declaring the constants and
+// re-implementing the backoff formula locally. The retry parameters live in
+// painlessmesh/tcp.hpp; TCP_CLIENT_CLEANUP_DELAY_MS and
+// TCP_CLIENT_DELETION_SPACING_MS live in painlessmesh/connection.hpp because
+// they are used from a destructor.
+
+SCENARIO("TCP connection retry defaults are configured correctly",
          "[tcp][retry][configuration]") {
-  GIVEN("The TCP retry configuration constants") {
-    THEN("TCP_CONNECT_MAX_RETRIES should be 5") {
-      REQUIRE(tcp_test::TCP_CONNECT_MAX_RETRIES == 5);
+  GIVEN("The default TCP retry configuration") {
+    tcp::TcpRetryConfig cfg;
+
+    THEN("maxRetries should be 5") { REQUIRE(cfg.maxRetries == 5); }
+
+    THEN("retryDelayMs should be 1000 (1 second)") {
+      REQUIRE(cfg.retryDelayMs == 1000);
     }
 
-    THEN("TCP_CONNECT_RETRY_DELAY_MS should be 1000 (1 second)") {
-      REQUIRE(tcp_test::TCP_CONNECT_RETRY_DELAY_MS == 1000);
-    }
-
-    THEN("TCP_CONNECT_STABILIZATION_DELAY_MS should be 500 (500ms)") {
-      REQUIRE(tcp_test::TCP_CONNECT_STABILIZATION_DELAY_MS == 500);
+    THEN("stabilizationDelayMs should be 500 (500ms)") {
+      REQUIRE(cfg.stabilizationDelayMs == 500);
     }
 
     THEN("TCP_CLIENT_CLEANUP_DELAY_MS should be 1000 (1000ms)") {
-      REQUIRE(tcp_test::TCP_CLIENT_CLEANUP_DELAY_MS == 1000);
+      REQUIRE(tcp::TCP_CLIENT_CLEANUP_DELAY_MS == 1000);
     }
 
     THEN("TCP_CLIENT_DELETION_SPACING_MS should be 1000 (1000ms)") {
-      REQUIRE(tcp_test::TCP_CLIENT_DELETION_SPACING_MS == 1000);
+      REQUIRE(tcp::TCP_CLIENT_DELETION_SPACING_MS == 1000);
     }
 
-    THEN("TCP_EXHAUSTION_RECONNECT_DELAY_MS should be 10000 (10 seconds)") {
-      REQUIRE(tcp_test::TCP_EXHAUSTION_RECONNECT_DELAY_MS == 10000);
+    THEN("exhaustionReconnectDelayMs should be 10000 (10 seconds)") {
+      REQUIRE(cfg.exhaustionReconnectDelayMs == 10000);
     }
   }
 }
 
-SCENARIO("Exponential backoff multiplier calculation works correctly",
+SCENARIO("Exponential backoff delay calculation works correctly",
          "[tcp][retry][backoff]") {
-  GIVEN("The exponential backoff formula: multiplier = min(2^retryCount, 8)") {
+  GIVEN("The default retry configuration") {
+    tcp::TcpRetryConfig cfg;
+
     WHEN("retryCount is 0") {
-      uint8_t retryCount = 0;
-      uint8_t expectedMultiplier = 1;  // 2^0 = 1
-      uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
-
-      THEN("The multiplier should be 1") {
-        REQUIRE(backoffMultiplier == expectedMultiplier);
-      }
-
-      THEN("The delay should be 1000ms") {
-        uint32_t delay = tcp_test::TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
-        REQUIRE(delay == 1000);
+      THEN("The delay should be 1000ms (multiplier 1)") {
+        REQUIRE(tcp::retryBackoffDelay(cfg, 0) == 1000);
       }
     }
 
     WHEN("retryCount is 1") {
-      uint8_t retryCount = 1;
-      uint8_t expectedMultiplier = 2;  // 2^1 = 2
-      uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
-
-      THEN("The multiplier should be 2") {
-        REQUIRE(backoffMultiplier == expectedMultiplier);
-      }
-
-      THEN("The delay should be 2000ms") {
-        uint32_t delay = tcp_test::TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
-        REQUIRE(delay == 2000);
+      THEN("The delay should be 2000ms (multiplier 2)") {
+        REQUIRE(tcp::retryBackoffDelay(cfg, 1) == 2000);
       }
     }
 
     WHEN("retryCount is 2") {
-      uint8_t retryCount = 2;
-      uint8_t expectedMultiplier = 4;  // 2^2 = 4
-      uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
-
-      THEN("The multiplier should be 4") {
-        REQUIRE(backoffMultiplier == expectedMultiplier);
-      }
-
-      THEN("The delay should be 4000ms") {
-        uint32_t delay = tcp_test::TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
-        REQUIRE(delay == 4000);
+      THEN("The delay should be 4000ms (multiplier 4)") {
+        REQUIRE(tcp::retryBackoffDelay(cfg, 2) == 4000);
       }
     }
 
     WHEN("retryCount is 3") {
-      uint8_t retryCount = 3;
-      uint8_t expectedMultiplier = 8;  // capped at 8
-      uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
-
-      THEN("The multiplier should be capped at 8") {
-        REQUIRE(backoffMultiplier == expectedMultiplier);
-      }
-
-      THEN("The delay should be 8000ms") {
-        uint32_t delay = tcp_test::TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
-        REQUIRE(delay == 8000);
+      THEN("The delay should be 8000ms (multiplier capped at 8)") {
+        REQUIRE(tcp::retryBackoffDelay(cfg, 3) == 8000);
       }
     }
 
     WHEN("retryCount is 4") {
-      uint8_t retryCount = 4;
-      uint8_t expectedMultiplier = 8;  // capped at 8
-      uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
+      THEN("The delay should remain 8000ms (multiplier still capped at 8)") {
+        REQUIRE(tcp::retryBackoffDelay(cfg, 4) == 8000);
+      }
+    }
 
-      THEN("The multiplier should remain capped at 8") {
-        REQUIRE(backoffMultiplier == expectedMultiplier);
+    WHEN("retryCount grows well beyond the cap") {
+      THEN("The delay does not keep doubling") {
+        // Demonstrates why the cap exists: without it, 1U << 20 would be a
+        // ~17 minute delay.
+        REQUIRE(tcp::retryBackoffDelay(cfg, 20) == 8000);
+      }
+    }
+  }
+}
+
+SCENARIO("Exponential backoff scales with a custom base delay",
+         "[tcp][retry][backoff][custom]") {
+  GIVEN("A configuration with a 200ms base retry delay") {
+    tcp::TcpRetryConfig cfg;
+    cfg.retryDelayMs = 200;
+
+    WHEN("Calculating the backoff sequence") {
+      std::vector<uint32_t> expectedDelays = {200, 400, 800, 1600, 1600};
+      std::vector<uint32_t> actualDelays;
+      for (size_t i = 0; i < expectedDelays.size(); ++i) {
+        actualDelays.push_back(
+            tcp::retryBackoffDelay(cfg, static_cast<uint8_t>(i)));
       }
 
-      THEN("The delay should be 8000ms") {
-        uint32_t delay = tcp_test::TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
-        REQUIRE(delay == 8000);
+      THEN("The sequence scales proportionally with the base delay") {
+        REQUIRE(actualDelays == expectedDelays);
       }
     }
   }
@@ -133,18 +122,16 @@ SCENARIO("Exponential backoff multiplier calculation works correctly",
 
 SCENARIO("Exponential backoff sequence is correct for all retry attempts",
          "[tcp][retry][backoff][sequence]") {
-  GIVEN("A complete retry sequence from 0 to TCP_CONNECT_MAX_RETRIES-1") {
+  GIVEN("A complete retry sequence for the default configuration") {
+    tcp::TcpRetryConfig cfg;
     // Expected delay sequence: 1s, 2s, 4s, 8s, 8s
     std::vector<uint32_t> expectedDelays = {1000, 2000, 4000, 8000, 8000};
 
     WHEN("Calculating delays for each retry attempt") {
       std::vector<uint32_t> actualDelays;
 
-      for (uint8_t retryCount = 0; retryCount < tcp_test::TCP_CONNECT_MAX_RETRIES;
-           ++retryCount) {
-        uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
-        uint32_t delay = tcp_test::TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
-        actualDelays.push_back(delay);
+      for (uint8_t retryCount = 0; retryCount < cfg.maxRetries; ++retryCount) {
+        actualDelays.push_back(tcp::retryBackoffDelay(cfg, retryCount));
       }
 
       THEN("The delay sequence should match expected values") {
@@ -162,6 +149,27 @@ SCENARIO("Exponential backoff sequence is correct for all retry attempts",
         }
         // 1000 + 2000 + 4000 + 8000 + 8000 = 23000ms = 23s
         REQUIRE(totalDelay == 23000);
+      }
+    }
+  }
+}
+
+SCENARIO("A maxRetries of zero disables retrying entirely",
+         "[tcp][retry][backoff][noretry]") {
+  GIVEN("A configuration with maxRetries set to 0") {
+    tcp::TcpRetryConfig cfg;
+    cfg.maxRetries = 0;
+
+    WHEN("Iterating the retry sequence the way tcp::connect() does") {
+      uint32_t attempts = 0;
+      for (uint8_t retryCount = 0; retryCount < cfg.maxRetries; ++retryCount) {
+        ++attempts;
+      }
+
+      THEN("No retry is ever scheduled") {
+        // The node falls straight through to the WiFi reconnect path, which is
+        // the low-latency behaviour requested in discussion #368.
+        REQUIRE(attempts == 0);
       }
     }
   }
@@ -189,37 +197,36 @@ SCENARIO("Backoff multiplier correctly implements bit shifting",
 SCENARIO("TCP exhaustion reconnect delay prevents rapid reconnection loops",
          "[tcp][retry][exhaustion][reconnect]") {
   GIVEN("All TCP connection retries have been exhausted") {
+    tcp::TcpRetryConfig cfg;
     uint32_t totalRetryDelay = 0;
-    
-    // Calculate total delay from all retry attempts (1s + 2s + 4s + 8s + 8s = 23s)
-    // Note: This backoff logic is duplicated from tcp.hpp to validate behavior
-    // Future: Consider extracting to shared utility function for consistency
-    for (uint8_t retryCount = 0; retryCount < tcp_test::TCP_CONNECT_MAX_RETRIES;
-         ++retryCount) {
-      uint8_t backoffMultiplier = (retryCount < 3) ? (1U << retryCount) : 8;
-      totalRetryDelay += tcp_test::TCP_CONNECT_RETRY_DELAY_MS * backoffMultiplier;
+
+    // Total delay from all retry attempts (1s + 2s + 4s + 8s + 8s = 23s),
+    // computed with the same helper tcp::connect() uses.
+    for (uint8_t retryCount = 0; retryCount < cfg.maxRetries; ++retryCount) {
+      totalRetryDelay += tcp::retryBackoffDelay(cfg, retryCount);
     }
-    
+
     WHEN("WiFi reconnection is scheduled after retry exhaustion") {
-      uint32_t reconnectDelay = tcp_test::TCP_EXHAUSTION_RECONNECT_DELAY_MS;
-      
+      uint32_t reconnectDelay = cfg.exhaustionReconnectDelayMs;
+
       THEN("The reconnect delay should be significantly longer than any single retry") {
         // 10 seconds vs 8 seconds (longest retry delay)
-        uint32_t maxSingleRetryDelay = tcp_test::TCP_CONNECT_RETRY_DELAY_MS * 8;
+        uint32_t maxSingleRetryDelay =
+            tcp::retryBackoffDelay(cfg, cfg.maxRetries - 1);
         REQUIRE(reconnectDelay > maxSingleRetryDelay);
       }
-      
+
       THEN("The reconnect delay should provide adequate recovery time") {
         // 10 seconds is reasonable for TCP server recovery
         REQUIRE(reconnectDelay >= 10000);
       }
-      
+
       THEN("Total time before reconnection should include all retries plus exhaustion delay") {
         // Total: 23s (retries) + 10s (exhaustion delay) = 33 seconds
         uint32_t totalTimeBeforeReconnect = totalRetryDelay + reconnectDelay;
         REQUIRE(totalTimeBeforeReconnect == 33000);
       }
-      
+
       THEN("The exhaustion delay prevents rapid loops that could occur in <1 second") {
         // Without exhaustion delay, reconnection could happen almost immediately
         // after the last retry, potentially creating a rapid loop
@@ -234,30 +241,30 @@ SCENARIO("AsyncClient deletion spacing prevents concurrent cleanup operations",
   GIVEN("Multiple AsyncClient objects need to be deleted") {
     // This scenario validates the fix for heap corruption during sendToInternet
     // operations where multiple AsyncClients are deleted in rapid succession
-    
+
     WHEN("Multiple deletions are scheduled simultaneously") {
-      uint32_t baseDelay = tcp_test::TCP_CLIENT_CLEANUP_DELAY_MS;
-      uint32_t spacing = tcp_test::TCP_CLIENT_DELETION_SPACING_MS;
-      
+      uint32_t baseDelay = tcp::TCP_CLIENT_CLEANUP_DELAY_MS;
+      uint32_t spacing = tcp::TCP_CLIENT_DELETION_SPACING_MS;
+
       THEN("Base cleanup delay should be adequate for single deletion") {
         // 1000ms is sufficient for AsyncTCP library to complete cleanup of one client
         REQUIRE(baseDelay >= 1000);
       }
-      
+
       THEN("Deletion spacing should prevent concurrent AsyncTCP cleanup") {
         // 1000ms spacing ensures each deletion completes before next one starts
         // Increased from 250ms to 1000ms for ESP32-C6 compatibility
         REQUIRE(spacing >= 500);
         REQUIRE(spacing <= 1500);
       }
-      
+
       THEN("Second deletion should be spaced from the first") {
         // If first deletion is at T+1000ms, second should be at T+1250ms or later
         uint32_t firstDeletionTime = baseDelay;
         uint32_t secondDeletionTime = firstDeletionTime + spacing;
         REQUIRE(secondDeletionTime >= firstDeletionTime + spacing);
       }
-      
+
       THEN("Multiple deletions should have cumulative spacing") {
         // For 4 concurrent deletion requests (sendToInternet high-churn scenario):
         // Deletion 1: 1000ms
@@ -266,63 +273,63 @@ SCENARIO("AsyncClient deletion spacing prevents concurrent cleanup operations",
         // Deletion 4: 3000ms + 1000ms = 4000ms
         uint32_t numDeletions = 4;
         std::vector<uint32_t> deletionTimes;
-        
+
         for (uint32_t i = 0; i < numDeletions; ++i) {
           uint32_t deletionTime = baseDelay + (i * spacing);
           deletionTimes.push_back(deletionTime);
         }
-        
+
         // Verify each deletion is properly spaced
         for (uint32_t i = 1; i < numDeletions; ++i) {
           uint32_t timeDiff = deletionTimes[i] - deletionTimes[i-1];
           REQUIRE(timeDiff == spacing);
         }
-        
+
         // Total spread should be base + (count-1)*spacing
         uint32_t totalSpread = deletionTimes.back() - deletionTimes.front();
         REQUIRE(totalSpread == (numDeletions - 1) * spacing);
         REQUIRE(totalSpread == 3000); // (4-1) * 1000ms = 3000ms
       }
     }
-    
+
     WHEN("High connection churn occurs (sendToInternet scenario)") {
       // Simulate scenario from bug report where multiple connections fail rapidly:
       // - BufferedConnection destructor schedules deletion
       // - tcp_err handler schedules deletion
       // - Another BufferedConnection destructor schedules deletion
       // Without spacing, all 3 would execute at nearly same time causing heap corruption
-      
+
       uint32_t numConcurrentDeletions = 3;
       std::vector<uint32_t> spacedDeletionTimes;
-      
+
       for (uint32_t i = 0; i < numConcurrentDeletions; ++i) {
-        uint32_t deletionTime = tcp_test::TCP_CLIENT_CLEANUP_DELAY_MS + 
-                                (i * tcp_test::TCP_CLIENT_DELETION_SPACING_MS);
+        uint32_t deletionTime = tcp::TCP_CLIENT_CLEANUP_DELAY_MS +
+                                (i * tcp::TCP_CLIENT_DELETION_SPACING_MS);
         spacedDeletionTimes.push_back(deletionTime);
       }
-      
+
       THEN("Deletions should be spread over time to prevent AsyncTCP interference") {
         // First: 1000ms, Second: 2000ms, Third: 3000ms
         REQUIRE(spacedDeletionTimes[0] == 1000);
         REQUIRE(spacedDeletionTimes[1] == 2000);
         REQUIRE(spacedDeletionTimes[2] == 3000);
       }
-      
+
       THEN("Total window should be reasonable for high-churn scenarios") {
         // 2000ms total spread (1000ms to 3000ms) provides adequate spacing for ESP32-C6
         uint32_t totalWindow = spacedDeletionTimes.back() - spacedDeletionTimes.front();
         REQUIRE(totalWindow == 2000);
         REQUIRE(totalWindow < 3000); // Keep it under 3 seconds for reasonable responsiveness
       }
-      
+
       THEN("Each deletion has time to complete before next starts") {
         // AsyncTCP library needs ~200-400ms per deletion on ESP32/ESP8266
         // ESP32-C6 requires significantly more time due to RISC-V architecture
         // 1000ms spacing provides robust buffer for all ESP32 variants
-        REQUIRE(tcp_test::TCP_CLIENT_DELETION_SPACING_MS >= 500);
+        REQUIRE(tcp::TCP_CLIENT_DELETION_SPACING_MS >= 500);
       }
     }
-    
+
     WHEN("Scheduler jitter causes execution time variation") {
       // This scenario validates the fix for the specific heap corruption bug where
       // deletions scheduled at T+1000ms and T+1250ms executed at T+1000ms and T+1220ms
@@ -331,7 +338,7 @@ SCENARIO("AsyncClient deletion spacing prevents concurrent cleanup operations",
       // The fix: Update lastScheduledDeletionTime when deletion EXECUTES, not just when scheduled.
       // This ensures subsequent deletions space from actual execution time, preventing
       // concurrent cleanup even with scheduler jitter.
-      
+
       THEN("Execution time tracking prevents concurrent cleanup despite scheduler jitter") {
         // Scenario from bug report:
         // - Deletion 1 scheduled for T+1000ms, executes at T+1000ms (on time)
@@ -342,49 +349,49 @@ SCENARIO("AsyncClient deletion spacing prevents concurrent cleanup operations",
         // With the fix: When deletion 2 executes (say at T+1230ms due to jitter),
         // it updates lastScheduledDeletionTime = millis() = 1230
         // Subsequent deletion 3 will space from 1230ms, not 1250ms, ensuring proper spacing
-        
-        uint32_t baseDelay = tcp_test::TCP_CLIENT_CLEANUP_DELAY_MS;
-        uint32_t spacing = tcp_test::TCP_CLIENT_DELETION_SPACING_MS;
-        
+
+        uint32_t baseDelay = tcp::TCP_CLIENT_CLEANUP_DELAY_MS;
+        uint32_t spacing = tcp::TCP_CLIENT_DELETION_SPACING_MS;
+
         // Simulate scenario:
         // T=0: Request deletion 1 -> scheduled at T+baseDelay
         uint32_t deletion1ScheduledTime = 0 + baseDelay;
-        
+
         // T=10: Request deletion 2 -> scheduled at T+(baseDelay+spacing)
         uint32_t deletion2ScheduledTime = deletion1ScheduledTime + spacing;
-        
+
         // Deletion 2 executes EARLY due to scheduler jitter (20ms before scheduled time)
         const uint32_t jitterMs = 20;  // Realistic scheduler jitter
         uint32_t deletion2ExecutionTime = deletion2ScheduledTime - jitterMs;
-        
+
         // T=20: Request deletion 3 - should space from deletion 2's EXECUTION, not schedule
         // With fix: spaces from actual execution + spacing
         uint32_t deletion3ScheduledTimeWithFix = deletion2ExecutionTime + spacing;
-        
+
         // Verify proper spacing from actual execution time
         uint32_t actualSpacingWithFix = deletion3ScheduledTimeWithFix - deletion2ExecutionTime;
         REQUIRE(actualSpacingWithFix >= spacing);  // Always maintains minimum spacing
-        
+
         // Calculate what the spacing would have been WITHOUT the fix
         // (spacing from scheduled time instead of execution time)
         uint32_t deletion3ScheduledTimeWithoutFix = deletion2ScheduledTime + spacing;
-        
+
         // Without fix, actual spacing depends on jitter direction:
         // - If task executes early (as in this example): spacing increases beyond minimum (adequate)
         // - If task executes late: spacing could fall below minimum (heap corruption!)
         // Example: deletion2 executes at 1270ms (20ms late)
         //          deletion3 scheduled at 1500ms (from scheduled time 1250 + 250)
         //          actual spacing: 1500 - 1270 = 230ms (too close! < 250ms)
-        
+
         // Demonstrate the fix handles jitter in both directions
         uint32_t deletion2ExecutionTimeLate = deletion2ScheduledTime + jitterMs;  // 20ms late
         uint32_t actualSpacingIfLate = deletion3ScheduledTimeWithoutFix - deletion2ExecutionTimeLate;
         REQUIRE(actualSpacingIfLate < spacing);  // Without fix: violates minimum spacing!
-        
+
         // This demonstrates that even with realistic jitter, we maintain minimum spacing
         // between actual deletion executions, preventing concurrent AsyncTCP cleanup
       }
-      
+
       THEN("Double-update strategy provides protection at both schedule and execution time") {
         // The fix updates lastScheduledDeletionTime in TWO places:
         // 1. When scheduling: Ensures minimum spacing between scheduled times
@@ -394,12 +401,12 @@ SCENARIO("AsyncClient deletion spacing prevents concurrent cleanup operations",
         // - Normal case: Both updates align, proper spacing maintained
         // - Jitter case: Execution update ensures spacing from actual time
         // - High load: Schedule-time spacing prevents scheduling too close together
-        
-        uint32_t spacing = tcp_test::TCP_CLIENT_DELETION_SPACING_MS;
-        
+
+        uint32_t spacing = tcp::TCP_CLIENT_DELETION_SPACING_MS;
+
         // Both updates use the same spacing constant
         REQUIRE(spacing == 1000);
-        
+
         // Minimum spacing is enforced at both stages
         REQUIRE(spacing >= 500);  // Adequate for ESP32-C6 AsyncTCP cleanup
         REQUIRE(spacing <= 1500);  // Still responsive

--- a/test/catch/catch_tcp_retry_config.cpp
+++ b/test/catch/catch_tcp_retry_config.cpp
@@ -1,0 +1,318 @@
+/**
+ * @file catch_tcp_retry_config.cpp
+ * @brief Tests for user-configurable TCP retry parameters (issue #378)
+ *
+ * Covers:
+ * - TcpRetryConfig defaults reproduce the legacy hardcoded constants
+ * - setTcpRetryConfig() / getTcpRetryConfig() round-trip
+ * - Clamping of the two values that can render a node unusable
+ * - Per-instance storage (the config must NOT be a namespace-scope global)
+ *
+ * NOTE ON COVERAGE: the retry path inside tcp::connect() is compiled out on
+ * desktop builds (it is guarded by
+ * `#if !defined(PAINLESSMESH_BOOST) && (defined(ESP32) || defined(ESP8266))`),
+ * so these tests verify the config plumbing and the backoff arithmetic, not
+ * the runtime onError -> reschedule -> reconnect chain. Verifying that
+ * requires hardware.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+#include "Arduino.h"
+
+// Global logger for test environment. Declared before mesh.hpp (which pulls in
+// tcp.hpp) because the non-template helpers there call Log, so it must be
+// visible at their point of definition.
+#include "painlessmesh/logger.hpp"
+
+painlessmesh::logger::LogClass Log;
+
+#include "painlessmesh/mesh.hpp"
+
+using namespace painlessmesh;
+
+SCENARIO("TcpRetryConfig defaults match the legacy hardcoded constants",
+         "[tcp][retry][config][defaults]") {
+  GIVEN("A default-constructed TcpRetryConfig") {
+    tcp::TcpRetryConfig cfg;
+
+    // This is the acceptance criterion "default values match current behavior
+    // exactly". The struct spells its defaults as these constants, so this
+    // guards against someone later replacing them with drifting literals.
+    THEN("maxRetries matches TCP_CONNECT_MAX_RETRIES") {
+      REQUIRE(cfg.maxRetries == tcp::TCP_CONNECT_MAX_RETRIES);
+      REQUIRE(cfg.maxRetries == 5);
+    }
+
+    THEN("retryDelayMs matches TCP_CONNECT_RETRY_DELAY_MS") {
+      REQUIRE(cfg.retryDelayMs == tcp::TCP_CONNECT_RETRY_DELAY_MS);
+      REQUIRE(cfg.retryDelayMs == 1000);
+    }
+
+    THEN("stabilizationDelayMs matches TCP_CONNECT_STABILIZATION_DELAY_MS") {
+      REQUIRE(cfg.stabilizationDelayMs ==
+              tcp::TCP_CONNECT_STABILIZATION_DELAY_MS);
+      REQUIRE(cfg.stabilizationDelayMs == 500);
+    }
+
+    THEN("exhaustionReconnectDelayMs matches TCP_EXHAUSTION_RECONNECT_DELAY_MS") {
+      REQUIRE(cfg.exhaustionReconnectDelayMs ==
+              tcp::TCP_EXHAUSTION_RECONNECT_DELAY_MS);
+      REQUIRE(cfg.exhaustionReconnectDelayMs == 10000);
+    }
+
+    THEN("failureBlockDurationMs matches TCP_FAILURE_BLOCK_DURATION_MS") {
+      REQUIRE(cfg.failureBlockDurationMs ==
+              tcp::TCP_FAILURE_BLOCK_DURATION_MS);
+      REQUIRE(cfg.failureBlockDurationMs == 60000);
+    }
+  }
+}
+
+SCENARIO("A fresh mesh reports default TCP retry configuration",
+         "[tcp][retry][config][defaults]") {
+  GIVEN("An initialised mesh that has never been configured") {
+    Scheduler scheduler;
+    Mesh<Connection> mesh;
+    mesh.init(&scheduler, 1234567);
+
+    THEN("getTcpRetryConfig returns the struct defaults") {
+      auto cfg = mesh.getTcpRetryConfig();
+      tcp::TcpRetryConfig defaults;
+
+      REQUIRE(cfg.maxRetries == defaults.maxRetries);
+      REQUIRE(cfg.retryDelayMs == defaults.retryDelayMs);
+      REQUIRE(cfg.stabilizationDelayMs == defaults.stabilizationDelayMs);
+      REQUIRE(cfg.exhaustionReconnectDelayMs ==
+              defaults.exhaustionReconnectDelayMs);
+      REQUIRE(cfg.failureBlockDurationMs == defaults.failureBlockDurationMs);
+    }
+  }
+}
+
+SCENARIO("setTcpRetryConfig round-trips an in-range configuration",
+         "[tcp][retry][config][roundtrip]") {
+  GIVEN("An initialised mesh") {
+    Scheduler scheduler;
+    Mesh<Connection> mesh;
+    mesh.init(&scheduler, 1234567);
+
+    WHEN("A custom in-range configuration is applied") {
+      tcp::TcpRetryConfig custom;
+      custom.maxRetries = 8;
+      custom.retryDelayMs = 250;
+      custom.stabilizationDelayMs = 100;
+      custom.exhaustionReconnectDelayMs = 2000;
+      custom.failureBlockDurationMs = 15000;
+      mesh.setTcpRetryConfig(custom);
+
+      THEN("getTcpRetryConfig returns it unchanged") {
+        auto cfg = mesh.getTcpRetryConfig();
+        REQUIRE(cfg.maxRetries == 8);
+        REQUIRE(cfg.retryDelayMs == 250);
+        REQUIRE(cfg.stabilizationDelayMs == 100);
+        REQUIRE(cfg.exhaustionReconnectDelayMs == 2000);
+        REQUIRE(cfg.failureBlockDurationMs == 15000);
+      }
+    }
+  }
+}
+
+SCENARIO("TCP retry configuration is stored per mesh instance",
+         "[tcp][retry][config][isolation]") {
+  // Regression test for the design decision that the config lives on the Mesh
+  // instance rather than at namespace scope in tcp.hpp. A namespace-scope
+  // mutable instance in a header would also give each translation unit its own
+  // silent copy. If someone later moves the storage, this fails loudly.
+  GIVEN("Two independently initialised meshes") {
+    Scheduler schedulerA;
+    Scheduler schedulerB;
+    Mesh<Connection> meshA;
+    Mesh<Connection> meshB;
+    meshA.init(&schedulerA, 1111111);
+    meshB.init(&schedulerB, 2222222);
+
+    WHEN("Only the first mesh is configured") {
+      tcp::TcpRetryConfig custom;
+      custom.maxRetries = 1;
+      custom.retryDelayMs = 100;
+      meshA.setTcpRetryConfig(custom);
+
+      THEN("The first mesh reports the custom values") {
+        REQUIRE(meshA.getTcpRetryConfig().maxRetries == 1);
+        REQUIRE(meshA.getTcpRetryConfig().retryDelayMs == 100);
+      }
+
+      THEN("The second mesh still reports defaults") {
+        tcp::TcpRetryConfig defaults;
+        REQUIRE(meshB.getTcpRetryConfig().maxRetries == defaults.maxRetries);
+        REQUIRE(meshB.getTcpRetryConfig().retryDelayMs ==
+                defaults.retryDelayMs);
+      }
+    }
+  }
+}
+
+SCENARIO("Out-of-range TCP retry values are clamped",
+         "[tcp][retry][config][clamping]") {
+  GIVEN("An initialised mesh") {
+    Scheduler scheduler;
+    Mesh<Connection> mesh;
+    mesh.init(&scheduler, 1234567);
+
+    WHEN("maxRetries exceeds the safe upper limit") {
+      tcp::TcpRetryConfig custom;
+      custom.maxRetries = 250;
+      mesh.setTcpRetryConfig(custom);
+
+      THEN("It is clamped to TCP_RETRY_MAX_RETRIES_LIMIT") {
+        // Each retry allocates an AsyncClient and recurses, so this bound is
+        // a heap and recursion-depth guard, not a style preference.
+        REQUIRE(mesh.getTcpRetryConfig().maxRetries ==
+                tcp::TCP_RETRY_MAX_RETRIES_LIMIT);
+      }
+    }
+
+    WHEN("retryDelayMs is zero") {
+      tcp::TcpRetryConfig custom;
+      custom.retryDelayMs = 0;
+      mesh.setTcpRetryConfig(custom);
+
+      THEN("It is raised to TCP_RETRY_MIN_DELAY_MS") {
+        // A zero delay would schedule retries with no spacing: a hot loop
+        // allocating an AsyncClient per scheduler tick.
+        REQUIRE(mesh.getTcpRetryConfig().retryDelayMs ==
+                tcp::TCP_RETRY_MIN_DELAY_MS);
+      }
+    }
+
+    WHEN("retryDelayMs is at the uint32_t maximum") {
+      tcp::TcpRetryConfig custom;
+      custom.retryDelayMs = 0xFFFFFFFF;
+      mesh.setTcpRetryConfig(custom);
+      auto cfg = mesh.getTcpRetryConfig();
+
+      THEN("It is lowered to TCP_RETRY_MAX_DELAY_MS") {
+        REQUIRE(cfg.retryDelayMs == tcp::TCP_RETRY_MAX_DELAY_MS);
+      }
+
+      THEN("The backoff multiplier cannot overflow the delay") {
+        // retryBackoffDelay multiplies by up to 8; the ceiling keeps that
+        // product two orders of magnitude clear of wrapping.
+        uint32_t maxDelay = tcp::retryBackoffDelay(cfg, 4);
+        REQUIRE(maxDelay > cfg.retryDelayMs);
+        REQUIRE(maxDelay == cfg.retryDelayMs * 8);
+      }
+    }
+  }
+}
+
+SCENARIO("Meaningful zero values survive the setter",
+         "[tcp][retry][config][clamping][zero]") {
+  GIVEN("An initialised mesh") {
+    Scheduler scheduler;
+    Mesh<Connection> mesh;
+    mesh.init(&scheduler, 1234567);
+
+    WHEN("maxRetries is set to zero") {
+      tcp::TcpRetryConfig custom;
+      custom.maxRetries = 0;
+      mesh.setTcpRetryConfig(custom);
+
+      THEN("It is preserved, not coerced to a minimum of one") {
+        // "Fail over to WiFi reconnect on the first TCP error" is exactly the
+        // low-latency profile requested in discussion #368.
+        REQUIRE(mesh.getTcpRetryConfig().maxRetries == 0);
+      }
+    }
+
+    WHEN("The unclamped delay fields are set to zero") {
+      tcp::TcpRetryConfig custom;
+      custom.stabilizationDelayMs = 0;
+      custom.exhaustionReconnectDelayMs = 0;
+      custom.failureBlockDurationMs = 0;
+      mesh.setTcpRetryConfig(custom);
+      auto cfg = mesh.getTcpRetryConfig();
+
+      THEN("They pass through untouched") {
+        // 0 is meaningful for each: skip stabilization, reconnect immediately,
+        // never blocklist.
+        REQUIRE(cfg.stabilizationDelayMs == 0);
+        REQUIRE(cfg.exhaustionReconnectDelayMs == 0);
+        REQUIRE(cfg.failureBlockDurationMs == 0);
+      }
+    }
+  }
+}
+
+SCENARIO("The documented tuning profiles are inside the legal envelope",
+         "[tcp][retry][config][profiles]") {
+  // Catches a doc/code split: if clamping ever tightens, the profiles shipped
+  // in examples/tcpRetryConfig and the docs would silently stop working as
+  // documented. Each profile must round-trip unchanged.
+  GIVEN("An initialised mesh") {
+    Scheduler scheduler;
+    Mesh<Connection> mesh;
+    mesh.init(&scheduler, 1234567);
+
+    WHEN("The real-time profile is applied") {
+      tcp::TcpRetryConfig realtime;
+      realtime.maxRetries = 1;
+      realtime.retryDelayMs = 200;
+      realtime.stabilizationDelayMs = 100;
+      realtime.exhaustionReconnectDelayMs = 1000;
+      realtime.failureBlockDurationMs = 5000;
+      mesh.setTcpRetryConfig(realtime);
+
+      THEN("It round-trips without clamping") {
+        auto cfg = mesh.getTcpRetryConfig();
+        REQUIRE(cfg.maxRetries == realtime.maxRetries);
+        REQUIRE(cfg.retryDelayMs == realtime.retryDelayMs);
+        REQUIRE(cfg.stabilizationDelayMs == realtime.stabilizationDelayMs);
+        REQUIRE(cfg.exhaustionReconnectDelayMs ==
+                realtime.exhaustionReconnectDelayMs);
+        REQUIRE(cfg.failureBlockDurationMs == realtime.failureBlockDurationMs);
+      }
+    }
+
+    WHEN("The high-reliability profile is applied") {
+      tcp::TcpRetryConfig reliable;
+      reliable.maxRetries = 10;
+      reliable.retryDelayMs = 2000;
+      reliable.stabilizationDelayMs = 1000;
+      reliable.exhaustionReconnectDelayMs = 30000;
+      reliable.failureBlockDurationMs = 180000;
+      mesh.setTcpRetryConfig(reliable);
+
+      THEN("It round-trips without clamping") {
+        auto cfg = mesh.getTcpRetryConfig();
+        REQUIRE(cfg.maxRetries == reliable.maxRetries);
+        REQUIRE(cfg.retryDelayMs == reliable.retryDelayMs);
+        REQUIRE(cfg.stabilizationDelayMs == reliable.stabilizationDelayMs);
+        REQUIRE(cfg.exhaustionReconnectDelayMs ==
+                reliable.exhaustionReconnectDelayMs);
+        REQUIRE(cfg.failureBlockDurationMs == reliable.failureBlockDurationMs);
+      }
+    }
+
+    WHEN("The battery-saver profile is applied") {
+      tcp::TcpRetryConfig battery;
+      battery.maxRetries = 2;
+      battery.retryDelayMs = 3000;
+      battery.stabilizationDelayMs = 500;
+      battery.exhaustionReconnectDelayMs = 60000;
+      battery.failureBlockDurationMs = 300000;
+      mesh.setTcpRetryConfig(battery);
+
+      THEN("It round-trips without clamping") {
+        auto cfg = mesh.getTcpRetryConfig();
+        REQUIRE(cfg.maxRetries == battery.maxRetries);
+        REQUIRE(cfg.retryDelayMs == battery.retryDelayMs);
+        REQUIRE(cfg.stabilizationDelayMs == battery.stabilizationDelayMs);
+        REQUIRE(cfg.exhaustionReconnectDelayMs ==
+                battery.exhaustionReconnectDelayMs);
+        REQUIRE(cfg.failureBlockDurationMs == battery.failureBlockDurationMs);
+      }
+    }
+  }
+}

--- a/test/ci/test_arduino.sh
+++ b/test/ci/test_arduino.sh
@@ -22,4 +22,5 @@ arduino-cli lib install AsyncTCP --config-dir test/ci/
 arduino-cli compile --fqbn esp32:esp32:esp32 examples/startHere/startHere.ino --config-dir test/ci/ &&
 arduino-cli compile --fqbn esp32:esp32:esp32 examples/namedMesh/namedMesh.ino --config-dir test/ci/ &&
 arduino-cli compile --fqbn esp32:esp32:esp32 examples/otaReceiver/otaReceiver.ino --config-dir test/ci/ &&
-arduino-cli compile --fqbn esp32:esp32:esp32 examples/otaSender/otaSender.ino --config-dir test/ci/
+arduino-cli compile --fqbn esp32:esp32:esp32 examples/otaSender/otaSender.ino --config-dir test/ci/ &&
+arduino-cli compile --fqbn esp32:esp32:esp32 examples/tcpRetryConfig/tcpRetryConfig.ino --config-dir test/ci/


### PR DESCRIPTION
Closes #378

## Summary

The five TCP connect-retry values were hardcoded as `static const` in `src/painlessmesh/tcp.hpp`. They are sound general-purpose defaults but wrong for several real deployments: real-time sensor/LED meshes ([discussion #368](https://github.com/Alteriom/painlessMesh/discussions/368)) want to fail fast and re-scan rather than stall 23 s in backoff; industrial meshes want to retry harder; battery nodes want fewer radio-on retries.

This adds `painlessmesh::tcp::TcpRetryConfig` plus `setTcpRetryConfig()` / `getTcpRetryConfig()` on `Mesh<T>`, and rewires the three consumers (`tcp::connect()`, `wifi::Mesh::tcpConnect()`, the blocklist call) to read the per-instance config.

**No behaviour change for existing sketches.** The struct's member defaults are spelled as the existing constants rather than as literals, so "defaults match current behaviour exactly" is enforced by the compiler and cannot drift. The constants themselves stay in place — `wifi.hpp` uses one as a default argument and downstream forks may reference them.

```cpp
painlessmesh::tcp::TcpRetryConfig cfg;   // starts at the defaults
cfg.maxRetries = 1;
cfg.retryDelayMs = 200;
cfg.exhaustionReconnectDelayMs = 1000;
mesh.setTcpRetryConfig(cfg);             // before mesh.init()
```

## Design notes

- **The config is a `Mesh` member, not a namespace-scope global.** A mutable namespace-scope instance in a header gives every translation unit its own private copy, so a sketch configuring the mesh in one TU and connecting from another would silently get defaults with no diagnostic. `catch_tcp_retry_config.cpp` pins this with a two-mesh isolation test that fails loudly if the storage is ever moved.
- **The accessors are public, not protected.** `mesh.hpp`'s friend declaration names `connect<T, Mesh<T>>`, but `wifi.hpp` instantiates `connect<Connection, wifi::Mesh>` — a *different* specialisation that is not a friend. This is the same reason the file already carries `public:  // Windows MSVC: TCP lambdas need access...`.
- **`connect()` snapshots the config once at entry and captures it by value.** The `onError` lambda outlives the frame, so reading the member later would let a user callback tear the backoff schedule mid-sequence. Each retry re-enters `connect()` and re-snapshots, so a change still takes effect on the next attempt.
- **Only two fields are clamped** — `maxRetries` (capped at 10) and `retryDelayMs` (50–60000 ms) — because they are the two that can render a node unusable: unbounded retries are a heap/recursion hazard, a zero delay is a hot loop allocating an `AsyncClient` per scheduler tick, and the ceiling keeps `retryDelayMs * 8` clear of `uint32_t` overflow. Zero is meaningful for every other field and passes through untouched, including `maxRetries = 0` (the real-time profile depends on it).
- **`failureBlockDurationMs = 0` now skips `blockNodeAfterTCPFailure()` entirely.** Previously a zero duration set `blockUntil = millis() + 0`, which `isNodeBlocked()` reads as already expired — a no-op block that merely leaked a blocklist entry until cleanup swept it. Only reachable when a user opts in to `0`, so this is not a default-path change.

## Tests

New `test/catch/catch_tcp_retry_config.cpp` (48 assertions): defaults match the legacy constants field-by-field, round-trip, per-instance isolation, clamping (upper/lower/overflow-ceiling), meaningful zeros, and the three documented profiles.

`catch_tcp_retry.cpp` and `catch_tcp_blocklist.cpp` previously re-declared the constants locally and re-implemented the backoff formula six times, against a stale comment claiming `tcp.hpp` could not be included. Both now call the real `tcp::retryBackoffDelay()` and read the real defaults, so they test shipped code rather than a copy.

**Writing the profile tests caught a bug in the profiles themselves:** the high-reliability profile paired a 126 s retry cycle + 30 s reconnect with a 120 s block duration, silently violating the invariant that a failed peer stays blocked longer than one full failure cycle. Raised to 180 s and pinned as a test across all three profiles.

## Verification

- Desktop build with CI's exact `-Wall -Werror`: clean, **0 warnings**.
- Full Catch2 suite: **41/41 binaries pass**.
- ASan build (CI's third matrix leg): builds clean, no AddressSanitizer diagnostics.
- Mutation-checked the new assertions — removing the `maxRetries` clamp and removing the backoff cap each make the suite fail, so the tests are not vacuous.
- The retry body is `#if`-guarded to ESP32/ESP8266 and never compiles on desktop, so it was **separately type-checked** by instantiating `tcp::connect()` with the guard forced on against real types — compiles clean under `-Wall -Werror`. That scratch harness is not part of this PR.

**Not covered by any automated test:** the runtime `onError → reschedule → reconnect` chain, which needs hardware. Suggested manual checks — two ESP32s plus a bridge: (1) real-time profile on the leaf, power-cycle the bridge, confirm it gives up after ~1 attempt and re-scans versus ~15 s of backoff on defaults; (2) `failureBlockDurationMs = 0` retries the same bridge IP immediately instead of being blocklisted; (3) `maxRetries = 250` prints a clamped `10` at startup.

## Docs / examples

- New `examples/tcpRetryConfig/` — `.ino` with three compile-time profiles (real-time, high-reliability, battery-saver), `platformio.ini`, and a README covering the tuning table, clamping rules, and the symptoms of tuning too aggressively.
- `docsify-site/api/configuration.md` and `USER_GUIDE.md` gain a TCP retry section; `keywords.txt` and `CHANGELOG.md` updated.
- Added the example to `test/ci/test_arduino.sh`. Note the `ci.yml` example loop guards on `[ -f "${example}*.ino" ]`, and `[ -f ]` does not glob — so that loop compiles nothing today and a new example gets no coverage unless added to `test_arduino.sh` explicitly. Fixing that glob is a separate one-line PR, deliberately not bundled here.

## Notes for the reviewer

- Version fields in `library.json` / `library.properties` / `package.json` are deliberately **not** touched — PR #383 is already moving them to 2.0.0 and a competing bump would conflict in three files for no benefit. This PR only appends to `CHANGELOG.md` under Unreleased.
- Expect a rebase against #383 (touches `mesh.hpp`, `keywords.txt`, `CHANGELOG.md`, `USER_GUIDE.md`, `docsify-site/*`) and #385 (`mesh.hpp`, `CHANGELOG.md`). The `mesh.hpp` diff was kept deliberately small and localised — one member plus two methods next to the `setInternet*` cluster — to minimise that.
- This is a footgun by design: `CHANGELOG.md:440-442` records that 1.9.x deliberately *raised* these values to fix real mesh instability, and an aggressive profile can reintroduce what that change fixed. Clamping only catches the catastrophic cases; the example README and API docs carry an explicit "defaults exist for a reason" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)