### PR TITLE
ci(release): dispatch PlatformIO publish explicitly + validate NPM auth in manual publish (refs #381)

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -41,9 +41,46 @@ jobs:
       id: version
       run: |
         VERSION=$(grep '^version=' library.properties | cut -d'=' -f2)
+        PKG_VERSION=$(jq -r '.version' package.json)
+
+        # npm publishes package.json's version — refuse to publish something
+        # other than the version this job reports.
+        if [ "$VERSION" != "$PKG_VERSION" ]; then
+          echo "❌ Version mismatch:"
+          echo "  library.properties: $VERSION"
+          echo "  package.json:       $PKG_VERSION"
+          echo "Align the version files on the default branch before publishing."
+          exit 1
+        fi
+
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Publishing version: $VERSION"
-    
+
+    - name: Verify NPM authentication
+      run: |
+        if [ -z "$NODE_AUTH_TOKEN" ]; then
+          echo "❌ NPM_TOKEN secret is not configured!"
+          echo "Please add NPM_TOKEN to repository secrets:"
+          echo "1. Go to repository Settings → Secrets and variables → Actions"
+          echo "2. Add NPM_TOKEN with your NPM access token"
+          echo "3. Generate token at: https://www.npmjs.com/settings/tokens"
+          exit 1
+        fi
+        echo "🔎 Validating NPM_TOKEN against registry (npm whoami)..."
+        if ! WHOAMI_OUT=$(npm whoami --registry=https://registry.npmjs.org 2>&1); then
+          echo "❌ NPM_TOKEN is set but invalid (npm whoami failed):"
+          echo "$WHOAMI_OUT"
+          echo ""
+          echo "The token has likely expired or been revoked. To fix:"
+          echo "1. Mint a new automation token at https://www.npmjs.com/settings/tokens"
+          echo "2. Update the NPM_TOKEN secret in repository settings"
+          echo "3. Re-run this workflow"
+          exit 1
+        fi
+        echo "✅ Authenticated to NPM as: $WHOAMI_OUT"
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     - name: Publish to NPM
       run: |
         echo " Publishing to NPM..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,15 +171,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: PlatformIO Library Registry
-        if: steps.tagcheck.outputs.exists == 'false' && (startsWith(steps.commit.outputs.message, 'release:') || steps.commit.outputs.is_version_bump == 'true')
-        run: |
-          echo "📦 PlatformIO Library Registry publication"
-          echo "✅ PlatformIO publication workflow will be triggered automatically"
-          echo "🔄 Check: https://github.com/${{ github.repository }}/actions/workflows/platformio-publish.yml"
-          echo "📋 Manual trigger: GitHub Actions → PlatformIO Library Publishing → Run workflow"
-          echo "📊 Monitor: https://registry.platformio.org/libraries"
-
       - name: Set release decision
         id: release_decision
         run: |
@@ -206,6 +197,62 @@ jobs:
           echo "- Version bump detected: ${{ steps.commit.outputs.is_version_bump }}" >> $GITHUB_STEP_SUMMARY
           echo "- Auto-release: ${{ (startsWith(steps.commit.outputs.message, 'release:') || steps.commit.outputs.is_version_bump == 'true') && steps.tagcheck.outputs.exists == 'false' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Changelog found: ${{ steps.changelog.outputs.has_changelog }}" >> $GITHUB_STEP_SUMMARY
+
+  # Trigger the PlatformIO Library Publishing workflow.
+  #
+  # platformio-publish.yml listens for `release: published`, but that event never
+  # fires for the release created above: GitHub suppresses events raised by the
+  # built-in GITHUB_TOKEN. workflow_dispatch and repository_dispatch are the two
+  # documented exceptions, so we dispatch explicitly instead. Kept as its own job
+  # so a dispatch failure surfaces as a red job without blocking npm-publish.
+  platformio-dispatch:
+    name: Trigger PlatformIO publish
+    needs: [tag-and-release]
+    runs-on: ubuntu-latest
+    if: needs.tag-and-release.outputs.should_release == 'true'
+
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+      - name: Dispatch PlatformIO Library Publishing
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.tag-and-release.outputs.version }}
+          WORKFLOW: platformio-publish.yml
+        run: |
+          # Newest existing run id, so we can prove a new one appeared.
+          BEFORE=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit 1 \
+            --json databaseId --jq '.[0].databaseId // 0')
+          echo "Newest existing $WORKFLOW run before dispatch: $BEFORE"
+
+          echo "🚀 Dispatching $WORKFLOW for v${VERSION} (ref: v${VERSION})..."
+          gh workflow run "$WORKFLOW" \
+            --repo "$REPO" \
+            --ref "v${VERSION}" \
+            -f version="${VERSION}"
+
+          # A dispatch that is accepted but creates no run is the exact failure
+          # mode this job exists to eliminate — verify rather than assume.
+          echo "⏳ Waiting for the dispatched run to appear..."
+          for _ in $(seq 1 12); do
+            sleep 5
+            AFTER=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit 1 \
+              --json databaseId --jq '.[0].databaseId // 0')
+            if [ "$AFTER" != "$BEFORE" ]; then
+              echo "✅ PlatformIO publish run started: https://github.com/$REPO/actions/runs/$AFTER"
+              echo "- PlatformIO publish: [run $AFTER](https://github.com/$REPO/actions/runs/$AFTER)" >> $GITHUB_STEP_SUMMARY
+              exit 0
+            fi
+          done
+
+          echo "❌ Dispatched $WORKFLOW but no new run appeared within 60s."
+          echo "Publish to the PlatformIO registry manually:"
+          echo "  gh workflow run $WORKFLOW --repo $REPO --ref v${VERSION} -f version=${VERSION}"
+          echo "Note: npm and GitHub Release publication are unaffected by this failure."
+          exit 1
 
   # Publish to NPM (public registry)
   npm-publish:

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -479,10 +479,15 @@ Rotating the token is operator-only — it cannot be automated from CI:
 ```bash
 # 1. Mint a fresh *Automation* token (Granular, scoped to @alteriom/painlessmesh)
 #    https://www.npmjs.com/settings/tokens
-# 2. Update the NPM_TOKEN repository secret
+# 2. Verify the new token before saving it (recommended).
+#    Ask the registry directly — do NOT use a bare `npm whoami`, which answers
+#    for whatever credential your local ~/.npmrc already holds and will happily
+#    pass while the new token is bad:
+curl -sS -H "Authorization: Bearer <new-token>" \
+  https://registry.npmjs.org/-/whoami          # -> {"username":"..."} , not 401
+
+# 3. Update the NPM_TOKEN repository secret
 #    https://github.com/Alteriom/painlessMesh/settings/secrets/actions
-# 3. Verify locally before saving (optional but recommended)
-NPM_TOKEN=<new-token> npm whoami --registry=https://registry.npmjs.org
 
 # 4a. Re-run the failed release job (keeps the original run's context)
 gh run rerun <run-id> --failed --repo Alteriom/painlessMesh

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -209,10 +209,21 @@ Each release triggers the **PlatformIO Library Publishing** workflow:
 
 #### Automatic Workflow Trigger
 
-The PlatformIO workflow automatically triggers on:
+The PlatformIO workflow is started by:
 
-- New GitHub releases (tags)
+- The `platformio-dispatch` job in **Automated Release**, which calls
+  `gh workflow run platformio-publish.yml --ref v<version> -f version=<version>`
+  right after the release is created
+- A GitHub release published by a human (via the UI or a PAT)
 - Manual workflow dispatch for testing
+
+> **Why the explicit dispatch?** `platformio-publish.yml` also listens for
+> `release: published`, but that event never fires for releases created by
+> `release.yml`: GitHub suppresses events raised by the built-in `GITHUB_TOKEN`.
+> `workflow_dispatch` is one of the two documented exceptions to that rule, so
+> the release workflow dispatches the publish explicitly and then verifies a run
+> actually appeared. Before this was added, PlatformIO publication silently did
+> not happen and had to be dispatched by hand (v1.9.21).
 
 ### PlatformIO Package Contents
 
@@ -454,12 +465,38 @@ npm run build
 npm run test
 ```
 
-**NPM Token Invalid**
+**NPM Token Expired / Invalid (`E401 Unauthorized`)**
+
+Symptom: the `npm-publish` job fails at *Verify NPM authentication* with
+`401 Unauthorized - GET https://registry.npmjs.org/-/whoami`. npm automation
+tokens expire; everything else in the release (tag, GitHub Release, zip asset,
+GitHub Packages, PlatformIO) succeeds independently, so **the release can look
+green-ish while npmjs.org is missing the version**. Always confirm with
+`npm view @alteriom/painlessmesh version`.
+
+Rotating the token is operator-only — it cannot be automated from CI:
+
 ```bash
-# Verify NPM authentication
-npm whoami
-# If not logged in: npm login
+# 1. Mint a fresh *Automation* token (Granular, scoped to @alteriom/painlessmesh)
+#    https://www.npmjs.com/settings/tokens
+# 2. Update the NPM_TOKEN repository secret
+#    https://github.com/Alteriom/painlessMesh/settings/secrets/actions
+# 3. Verify locally before saving (optional but recommended)
+NPM_TOKEN=<new-token> npm whoami --registry=https://registry.npmjs.org
+
+# 4a. Re-run the failed release job (keeps the original run's context)
+gh run rerun <run-id> --failed --repo Alteriom/painlessMesh
+
+# 4b. …or republish the current version out-of-band
+gh workflow run manual-publish.yml --repo Alteriom/painlessMesh \
+  -f publish_npm=true -f publish_github=false
+
+# 5. Confirm the version actually landed
+npm view @alteriom/painlessmesh version
 ```
+
+While rotating `NPM_TOKEN`, check `PLATFORMIO_AUTH_TOKEN` too — it expires the
+same way and `platformio-publish.yml` hard-fails on an invalid one.
 
 **GitHub Packages Authentication**
 ```bash
@@ -508,10 +545,17 @@ If this happens, you can manually publish packages:
 4. Click **Run workflow**
 
 The manual workflow will:
-- Read the current version from `library.properties`
+- Read the current version from `library.properties` and refuse to run if it
+  disagrees with `package.json` (npm publishes the `package.json` version)
+- Validate `NPM_TOKEN` against the registry before attempting to publish, so an
+  expired token fails immediately with rotation instructions
 - Publish to NPM (if selected)
 - Publish to GitHub Packages (if selected)
 - Show success/failure status for each
+
+It does **not** publish to the PlatformIO registry — use
+`gh workflow run platformio-publish.yml --ref v<version> -f version=<version>`
+for that.
 
 Alternatively, from command line:
 ```bash
@@ -649,6 +693,11 @@ Monitor your releases:
 - `GITHUB_TOKEN`: Automatically provided by GitHub Actions
 - `NPM_TOKEN`: Required for NPM publishing (add in repository secrets)
 - `PLATFORMIO_AUTH_TOKEN`: Required for PlatformIO Library Registry publishing
+
+Both `NPM_TOKEN` and `PLATFORMIO_AUTH_TOKEN` are user-minted tokens that
+**expire**. Their expiry is invisible until a release fails, so rotate them
+together and re-check after any expiry date you set. See
+[NPM Token Expired / Invalid](#-troubleshooting) for the rotation runbook.
 
 ### Repository Settings
 - **Actions**: Enabled with write permissions


### PR DESCRIPTION
Follow-up to #392 on issue #381. Fixes the two automatable items in that ticket; the NPM_TOKEN rotation itself is still operator-only and is **not** done here.

## Verified current state

- npm `@alteriom/painlessmesh` latest is still **1.9.20** — v1.9.21 never published (`npm view @alteriom/painlessmesh dist-tags`)
- release run [30866889994](https://github.com/Alteriom/painlessMesh/actions/runs/30866889994) is still red and has not been re-run; the two later release runs (08-07, 08-08) skipped `npm-publish` (`should_release=false`), so the token has not been exercised since
- `#392`'s fail-fast whoami check is on `main`

## 1. PlatformIO publish is now actually triggered

`platformio-publish.yml` only listens for `release: published`. That event **never fires** for the release `release.yml` creates, because GitHub suppresses events raised by the built-in `GITHUB_TOKEN`. The old step in `release.yml` just echoed:

> ✅ PlatformIO publication workflow will be triggered automatically

which was false — for v1.9.21 it had to be dispatched by hand.

Replaced with a `platformio-dispatch` job that calls `gh workflow run platformio-publish.yml --ref v<version> -f version=<version>`. `workflow_dispatch` is one of the two documented exceptions to the suppression rule, so no PAT is needed. The job then polls up to 60s for a new run id and fails loudly with the manual command if none appeared — a dispatch that is accepted but creates no run is exactly the silent failure this replaces.

It is a **separate job** on purpose: a step inside `tag-and-release` that failed would skip `npm-publish` (which `needs` that job). As its own job, a dispatch failure is red and attributable without blocking npm.

## 2. `manual-publish.yml` hardened

This is the workflow an operator runs to republish a version after rotating the token, and it had neither guard:

- **Validate `NPM_TOKEN` with `npm whoami` before publishing** — mirrors the check #392 added to `release.yml`. Without it the operator gets a raw `E401` at the publish call instead of an early failure with rotation instructions.
- **Refuse to run on a version mismatch** — the job reports `library.properties`'s version while npm publishes `package.json`'s. If they diverge it silently publishes the wrong one.

## 3. `RELEASE_GUIDE.md`

- Documents the dispatch mechanism and why `release: published` alone is not enough
- Replaces the two-line "NPM Token Invalid" stub with a rotation runbook for the exact #381 failure: symptoms, why the release still looks mostly green, rotation steps, how to republish a missed version, and how to verify it landed
- Notes `PLATFORMIO_AUTH_TOKEN` expires the same way and should be rotated alongside

## Testing

Workflow-only change, so no repo test suite covers it. Verified by:

- `actionlint` clean on all workflows in `.github/workflows/`
- Extracted the dispatch step's shell into a harness with a stubbed `gh` and exercised both paths: run-appears → exit 0 + step-summary link; no-run-appears → exit 1 with the manual remediation command
- Extracted the version step and ran it against matching (exit 0, sets output) and mismatched (exit 1, prints both versions) fixtures
- `prettier --check` fails on all three files both before and after this change — pre-existing, and prettier is not CI-gated

The dispatch itself can only be proven end-to-end by the next real release; the 60s verification poll exists so that if it does not work, the release says so instead of going quiet.

## Still operator-only

Rotating `NPM_TOKEN` (and checking `PLATFORMIO_AUTH_TOKEN`) — see the [status comment on #381](https://github.com/Alteriom/painlessMesh/issues/381#issuecomment-5185904096). v1.9.21 remains unpublished on npmjs.org until that happens.

Refs #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)