### PR TITLE
ci(release): explain npm publish failures instead of echoing npm's error codes (refs #381)

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -72,7 +72,9 @@ jobs:
           echo "$WHOAMI_OUT"
           echo ""
           echo "The token has likely expired or been revoked. To fix:"
-          echo "1. Mint a new automation token at https://www.npmjs.com/settings/tokens"
+          echo "1. Mint a new granular token at https://www.npmjs.com/settings/tokens"
+          echo "   - Packages and scopes: Read and write on @alteriom/painlessmesh"
+          echo "   - Enable 'Bypass 2FA' — without it the publish fails with EOTP"
           echo "2. Update the NPM_TOKEN secret in repository settings"
           echo "3. Re-run this workflow"
           exit 1
@@ -82,9 +84,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Publish to NPM
-      run: |
-        echo " Publishing to NPM..."
-        npm publish --access public
+      run: ./scripts/npm-publish.sh
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,12 +289,16 @@ jobs:
           echo "$WHOAMI_OUT"
           echo ""
           echo "The token has likely expired or been revoked. To fix:"
-          echo "1. Mint a new automation token at https://www.npmjs.com/settings/tokens"
+          echo "1. Mint a new granular token at https://www.npmjs.com/settings/tokens"
+          echo "   - Packages and scopes: Read and write on @alteriom/painlessmesh"
+          echo "   - Enable 'Bypass 2FA' — without it the publish fails with EOTP"
           echo "2. Update the NPM_TOKEN secret in repository settings"
           echo "3. Re-run this workflow"
           exit 1
         fi
         echo "✅ Authenticated to NPM as: $WHOAMI_OUT"
+        echo "ℹ️  Note: whoami only proves the token is valid, not that it may"
+        echo "   publish without a 2FA challenge — that surfaces at publish time."
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     
@@ -312,19 +316,7 @@ jobs:
         fi
     
     - name: Publish to NPM
-      run: |
-        echo "📦 Publishing to NPM..."
-        echo "Registry: $(npm config get registry)"
-        echo "Package name: $(jq -r '.name' package.json)"
-        echo "Package version: $(jq -r '.version' package.json)"
-        
-        # Verify we're publishing to the correct registry
-        if [ "$(npm config get registry)" != "https://registry.npmjs.org/" ]; then
-          echo "⚠️  Warning: NPM registry is not set to public NPM!"
-          npm config set registry https://registry.npmjs.org/
-        fi
-        
-        npm publish --access public
+      run: ./scripts/npm-publish.sh
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -468,8 +468,8 @@ npm run test
 **NPM Token Expired / Invalid (`E401 Unauthorized`)**
 
 Symptom: the `npm-publish` job fails at *Verify NPM authentication* with
-`401 Unauthorized - GET https://registry.npmjs.org/-/whoami`. npm automation
-tokens expire; everything else in the release (tag, GitHub Release, zip asset,
+`401 Unauthorized - GET https://registry.npmjs.org/-/whoami`. npm tokens
+expire; everything else in the release (tag, GitHub Release, zip asset,
 GitHub Packages, PlatformIO) succeeds independently, so **the release can look
 green-ish while npmjs.org is missing the version**. Always confirm with
 `npm view @alteriom/painlessmesh version`.
@@ -477,7 +477,8 @@ green-ish while npmjs.org is missing the version**. Always confirm with
 Rotating the token is operator-only — it cannot be automated from CI:
 
 ```bash
-# 1. Mint a fresh *Automation* token (Granular, scoped to @alteriom/painlessmesh)
+# 1. Mint a fresh granular token, scoped to @alteriom/painlessmesh, with
+#    "Read and write" AND the "Bypass 2FA" option enabled  <-- see EOTP below
 #    https://www.npmjs.com/settings/tokens
 # 2. Verify the new token before saving it (recommended).
 #    Ask the registry directly — do NOT use a bare `npm whoami`, which answers
@@ -502,6 +503,60 @@ npm view @alteriom/painlessmesh version
 
 While rotating `NPM_TOKEN`, check `PLATFORMIO_AUTH_TOKEN` too — it expires the
 same way and `platformio-publish.yml` hard-fails on an invalid one.
+
+**NPM asks for a one-time password (`EOTP`)**
+
+Symptom: authentication *succeeds* — `npm whoami` prints the username — and then
+`npm publish` fails with:
+
+```
+npm error code EOTP
+npm error This operation requires a one-time password from your authenticator.
+```
+
+The token is valid but is not allowed to bypass 2FA, and CI has no authenticator
+to answer the challenge with. **A rotation that fixes `E401` lands here if the
+replacement token is minted without the bypass option** — which is what happened
+on the second rotation attempt for #381.
+
+npm removed the legacy token types (`read-only` / `automation` / `publish`) in
+**November 2025**; only granular access tokens exist now. The old *Automation*
+token bypassed 2FA by virtue of its type, so this was never a decision anyone had
+to make. On a granular token it is an explicit checkbox, and a token minted from
+muscle memory does not have it:
+
+> **Bypass 2FA** — required. Takes precedence over account-level and
+> package-level 2FA settings for publishing.
+
+Re-mint at <https://www.npmjs.com/settings/tokens> with *Read and write* on
+`@alteriom/painlessmesh` **and Bypass 2FA enabled**, update the secret, re-run.
+`npm whoami` cannot detect this ahead of time — it passes for both token kinds,
+so the failure necessarily surfaces at the publish call.
+
+### Trusted publishing (OIDC) — the way out of token rotation
+
+Both failures above are symptoms of the same thing: a long-lived credential that
+expires silently and is only exercised on release day. npm's replacement is
+**trusted publishing** — the workflow authenticates to npm over OIDC, and
+`NPM_TOKEN` stops existing.
+
+This is on a clock rather than merely being nicer: as of **2026-07-31** bypass-2FA
+tokens can no longer manage tokens, package access, or trusted-publishing config,
+and npm has targeted **January 2027** for removing *direct publish* from them —
+after which they can only stage a publish for a maintainer to approve with 2FA.
+The current setup stops working at that point.
+
+Requirements, none of which this repo blocks on today:
+
+| Requirement | Status here |
+|---|---|
+| `id-token: write` permission | ✅ already set in `release.yml` and `manual-publish.yml` |
+| npm CLI ≥ 11.5.1, Node ≥ 22.14.0 | ❌ workflows pin `node-version: '18'` — needs a bump |
+| Trusted publisher registered on npmjs.com | ❌ operator, one-time, per workflow file |
+
+The npmjs.com side is under *Package settings → Trusted publisher*: org
+`Alteriom`, repository `painlessMesh`, workflow filename `release.yml` (add a
+second entry for `manual-publish.yml` if that path should keep working).
 
 **GitHub Packages Authentication**
 ```bash

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Publish the package to npmjs.org, translating npm's failure codes into the
+# action the operator actually has to take.
+#
+# npm reports credential problems as short codes (E401, EOTP, E403) whose fix is
+# a specific, non-obvious click on npmjs.com. Issue #381 cost two operator
+# round-trips for exactly this reason: an expired token (E401), then a
+# replacement token that authenticated but could not publish (EOTP).
+#
+# Used by .github/workflows/release.yml and .github/workflows/manual-publish.yml.
+# Expects NODE_AUTH_TOKEN in the environment and an .npmrc that consumes it
+# (actions/setup-node with registry-url writes one).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+PACKAGE_NAME="$(jq -r '.name' package.json)"
+PACKAGE_VERSION="$(jq -r '.version' package.json)"
+TOKEN_URL="https://www.npmjs.com/settings/tokens"
+
+echo "📦 Publishing to NPM..."
+echo "Registry: $(npm config get registry)"
+echo "Package name: $PACKAGE_NAME"
+echo "Package version: $PACKAGE_VERSION"
+
+# Verify we're publishing to the correct registry
+if [ "$(npm config get registry)" != "https://registry.npmjs.org/" ]; then
+    echo "⚠️  Warning: NPM registry is not set to public NPM!"
+    npm config set registry https://registry.npmjs.org/
+fi
+
+set +e
+PUBLISH_OUT=$(npm publish --access public 2>&1)
+PUBLISH_RC=$?
+set -e
+
+echo "$PUBLISH_OUT"
+
+if [ "$PUBLISH_RC" -eq 0 ]; then
+    exit 0
+fi
+
+echo ""
+echo "=================================================================="
+
+case "$PUBLISH_OUT" in
+*EOTP* | *"one-time password"*)
+    cat <<EOF
+❌ npm demanded a one-time password (EOTP).
+
+The token is valid — it authenticated — but it is not permitted to publish
+without a 2FA challenge, which CI cannot answer.
+
+Fix: mint a replacement granular token at
+  $TOKEN_URL
+  • Packages and scopes: Read and write, limited to $PACKAGE_NAME
+  • Enable "Bypass 2FA"   <-- the setting that is missing here
+
+npm removed the legacy "Automation" token type in November 2025. A granular
+token without "Bypass 2FA" behaves like the old "Publish" token and lands
+exactly here, so a token minted by muscle memory hits this.
+
+Then update the NPM_TOKEN repository secret and re-run.
+
+Longer term: npm is removing direct publish from bypass-2FA tokens
+(targeted January 2027). Migrating to trusted publishing (OIDC) retires
+NPM_TOKEN entirely — see RELEASE_GUIDE.md, "Trusted publishing (OIDC)".
+EOF
+    ;;
+*E401* | *"401 Unauthorized"*)
+    cat <<EOF
+❌ npm rejected the credentials (401).
+
+The NPM_TOKEN secret has expired or been revoked. Mint a replacement at
+  $TOKEN_URL
+  • Packages and scopes: Read and write, limited to $PACKAGE_NAME
+  • Enable "Bypass 2FA" (CI cannot answer a 2FA prompt)
+
+Verify it before saving the secret:
+  curl -sS -H "Authorization: Bearer <new-token>" https://registry.npmjs.org/-/whoami
+
+Then update the NPM_TOKEN repository secret and re-run.
+EOF
+    ;;
+*"cannot publish over"* | *"You cannot publish over the previously published versions"*)
+    cat <<EOF
+✅/❌ Version $PACKAGE_VERSION is already published to npm.
+
+Nothing to do if this is a re-run of an already-successful release. If this
+is a new release, the version was not bumped — npm versions are immutable, so
+publish a new version rather than trying to overwrite this one.
+EOF
+    ;;
+*E403* | *"403 Forbidden"*)
+    cat <<EOF
+❌ npm accepted the credentials but refused the write (403).
+
+The token authenticates but lacks write access to $PACKAGE_NAME, or the
+account is not a maintainer of it. Check the token's package scope at
+  $TOKEN_URL
+and the maintainer list at
+  https://www.npmjs.com/package/$PACKAGE_NAME/access
+EOF
+    ;;
+*)
+    echo "❌ npm publish failed (exit $PUBLISH_RC). See the npm output above."
+    ;;
+esac
+
+echo "=================================================================="
+echo ""
+echo "Note: the GitHub Release, GitHub Packages, and PlatformIO publication"
+echo "are independent of this job and may well have succeeded. Confirm what"
+echo "actually landed on npm with:"
+echo "  npm view $PACKAGE_NAME version"
+
+exit "$PUBLISH_RC"


### PR DESCRIPTION
Follow-up to #392 / #399 on #381, prompted by what happened when the token was actually rotated.

## What the rotation revealed

`NPM_TOKEN` was refreshed and I re-ran the failed v1.9.21 job ([run 30866889994](https://github.com/Alteriom/painlessMesh/actions/runs/30866889994)). The `E401` is gone — `npm whoami` now prints `sparck75` — and the publish failed anyway:

```
npm error code EOTP
npm error This operation requires a one-time password from your authenticator.
```

The replacement token authenticates but was minted without **Bypass 2FA**, so it cannot publish non-interactively. This is not operator error so much as a trap: npm **removed the legacy `automation` / `publish` / `read-only` token types in November 2025**, and the old *Automation* token bypassed 2FA by virtue of its type. On a granular token it is an explicit checkbox, so a token minted the way it always was minted lands here.

Critically, **#392's fail-fast `npm whoami` check cannot catch this** — whoami passes for both kinds of token. The diagnosis can only happen at the publish call, which makes the text printed there the entire remediation surface. Today that text is npm's raw `EOTP`.

## Change

Both publish paths (`release.yml`, `manual-publish.yml`) now run `scripts/npm-publish.sh`, which classifies the failure:

| npm output | What the operator is told |
|---|---|
| `EOTP` | Re-mint granular, *Read and write* on the package, **Bypass 2FA enabled** — plus why the Automation token that used to make this automatic is gone |
| `E401` | Token expired/revoked; rotate, with the `curl` pre-check from #399 |
| `cannot publish over` | Version already live; immutable, bump instead |
| `E403` | Authenticated but no write access — token scope or maintainer list |
| anything else | Falls through to npm's own output |

Every failure also notes that the GitHub Release / GitHub Packages / PlatformIO publications are independent and likely succeeded, with `npm view` to check — the "release looks green but npm is missing the version" confusion that opened #381.

Consolidating into a script rather than duplicating the block keeps the two workflows from drifting, and made the logic directly testable.

## `RELEASE_GUIDE.md`

- EOTP runbook, including that `npm whoami` provably cannot pre-detect it
- Corrects the rotation steps to require **Bypass 2FA** (they said *Automation*, a type that no longer exists)
- New **Trusted publishing (OIDC)** section. This matters beyond tidiness: npm restricted bypass-2FA tokens on 2026-07-31 and has targeted **January 2027** for removing direct publish from them, after which they can only *stage* a publish for a maintainer to approve with 2FA. The token path this issue keeps repairing has a known expiry date. `id-token: write` is already set in both workflows; what is missing is the Node 18 → 22 bump and a one-time trusted-publisher registration on npmjs.com. Documented, not done here — it needs the npmjs.com side first, and I did not want it riding along with a diagnostics change.

## Testing

Workflow/script change, so no repo suite covers it. Verified by:

- Both workflow files parse; `bash -n` clean
- Ran `scripts/npm-publish.sh` against a stubbed `npm` for all six paths — success, `EOTP`, `E401`, duplicate-version, `E403`, and an unrecognised error — confirming each prints its intended remediation and propagates npm's exit code rather than masking it
- Script committed `100755`

## Still blocked on the operator

v1.9.21 is **still unpublished** (`npm view @alteriom/painlessmesh version` → `1.9.20`). Re-mint `NPM_TOKEN` with Bypass 2FA enabled and re-run; this PR only ensures the next person gets told that directly.

Refs #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)