### PR TITLE
ci(release): publish by tag + stop teaching operators to shadow the org NPM_TOKEN (refs #381)

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -3,6 +3,11 @@ name: Manual Package Publishing
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Git ref to publish (e.g. v1.9.21). Defaults to the default branch — set this when republishing a version whose tag is behind main.'
+        required: false
+        type: string
+        default: ''
       publish_npm:
         description: 'Publish to NPM Registry'
         required: true
@@ -27,7 +32,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+      with:
+        ref: ${{ inputs.ref }}
+        # Tags are needed by "Verify the checkout matches the release tag".
+        fetch-depth: 0
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
@@ -56,14 +65,56 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Publishing version: $VERSION"
 
+    - name: Verify the checkout matches the release tag
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+        TAG="v$VERSION"
+
+        if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+          echo "ℹ️  No tag $TAG exists — publishing an untagged version."
+          echo "   Expected for a first publication; otherwise cut the release first."
+          exit 0
+        fi
+
+        TAG_SHA=$(git rev-list -n1 "$TAG")
+        HEAD_SHA=$(git rev-parse HEAD)
+
+        if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+          cat <<EOF
+        ❌ Refusing to publish $VERSION from a commit that is not $TAG.
+
+          checked out: $HEAD_SHA
+          $TAG:        $TAG_SHA
+
+        The version files still say $VERSION, but this ref has moved on since the
+        tag — so this job would upload today's code to npm under an old version
+        number. npm versions are immutable, so that is unfixable after the fact:
+        npm $VERSION would permanently disagree with git $TAG and with the
+        GitHub Release assets.
+
+        If you are republishing a release npm missed (see issue #381), publish the
+        tag itself:
+          gh workflow run manual-publish.yml --repo Alteriom/painlessMesh \\
+            -f ref=$TAG -f publish_npm=true -f publish_github=false
+
+        If you meant to ship the newer code, bump the version on the default
+        branch and cut a normal release instead.
+        EOF
+          exit 1
+        fi
+
+        echo "✅ Checkout is exactly $TAG ($TAG_SHA)"
+
     - name: Verify NPM authentication
       run: |
         if [ -z "$NODE_AUTH_TOKEN" ]; then
-          echo "❌ NPM_TOKEN secret is not configured!"
-          echo "Please add NPM_TOKEN to repository secrets:"
-          echo "1. Go to repository Settings → Secrets and variables → Actions"
-          echo "2. Add NPM_TOKEN with your NPM access token"
-          echo "3. Generate token at: https://www.npmjs.com/settings/tokens"
+          echo "❌ NPM_TOKEN is empty!"
+          echo "This repo inherits NPM_TOKEN from the Alteriom *organisation*"
+          echo "secrets — it has no repository-level copy, and should not get one"
+          echo "(a repo secret shadows the org secret and rotting separately is"
+          echo "exactly how this breaks). Check that the org secret exists and"
+          echo "that painlessMesh is in its repository-access list:"
+          echo "  https://github.com/organizations/Alteriom/settings/secrets/actions"
           exit 1
         fi
         echo "🔎 Validating NPM_TOKEN against registry (npm whoami)..."
@@ -75,7 +126,8 @@ jobs:
           echo "1. Mint a new granular token at https://www.npmjs.com/settings/tokens"
           echo "   - Packages and scopes: Read and write on @alteriom/painlessmesh"
           echo "   - Enable 'Bypass 2FA' — without it the publish fails with EOTP"
-          echo "2. Update the NPM_TOKEN secret in repository settings"
+          echo "2. Update the NPM_TOKEN *organisation* secret (not a repo secret):"
+          echo "   https://github.com/organizations/Alteriom/settings/secrets/actions"
           echo "3. Re-run this workflow"
           exit 1
         fi
@@ -107,7 +159,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+      with:
+        ref: ${{ inputs.ref }}
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,11 +276,13 @@ jobs:
     - name: Verify NPM authentication
       run: |
         if [ -z "$NODE_AUTH_TOKEN" ]; then
-          echo "❌ NPM_TOKEN secret is not configured!"
-          echo "Please add NPM_TOKEN to repository secrets:"
-          echo "1. Go to repository Settings → Secrets and variables → Actions"
-          echo "2. Add NPM_TOKEN with your NPM access token"
-          echo "3. Generate token at: https://www.npmjs.com/settings/tokens"
+          echo "❌ NPM_TOKEN is empty!"
+          echo "This repo inherits NPM_TOKEN from the Alteriom *organisation*"
+          echo "secrets — it has no repository-level copy, and should not get one"
+          echo "(a repo secret shadows the org secret and rotting separately is"
+          echo "exactly how this breaks). Check that the org secret exists and"
+          echo "that painlessMesh is in its repository-access list:"
+          echo "  https://github.com/organizations/Alteriom/settings/secrets/actions"
           exit 1
         fi
         echo "🔎 Validating NPM_TOKEN against registry (npm whoami)..."
@@ -292,7 +294,8 @@ jobs:
           echo "1. Mint a new granular token at https://www.npmjs.com/settings/tokens"
           echo "   - Packages and scopes: Read and write on @alteriom/painlessmesh"
           echo "   - Enable 'Bypass 2FA' — without it the publish fails with EOTP"
-          echo "2. Update the NPM_TOKEN secret in repository settings"
+          echo "2. Update the NPM_TOKEN *organisation* secret (not a repo secret):"
+          echo "   https://github.com/organizations/Alteriom/settings/secrets/actions"
           echo "3. Re-run this workflow"
           exit 1
         fi

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -487,18 +487,46 @@ Rotating the token is operator-only — it cannot be automated from CI:
 curl -sS -H "Authorization: Bearer <new-token>" \
   https://registry.npmjs.org/-/whoami          # -> {"username":"..."} , not 401
 
-# 3. Update the NPM_TOKEN repository secret
-#    https://github.com/Alteriom/painlessMesh/settings/secrets/actions
+# 3. Update the NPM_TOKEN *organisation* secret — NOT a repository secret.
+#    painlessMesh has no repo-level NPM_TOKEN and must not gain one; see
+#    "Where NPM_TOKEN actually lives" below.
+#    https://github.com/organizations/Alteriom/settings/secrets/actions
 
 # 4a. Re-run the failed release job (keeps the original run's context)
 gh run rerun <run-id> --failed --repo Alteriom/painlessMesh
 
-# 4b. …or republish the current version out-of-band
+# 4b. …or republish a missed version out-of-band. Pass the TAG as ref:
+#     without it the workflow builds the default branch, and if main has moved
+#     on since the tag it would upload today's code under the old version
+#     number. The workflow now refuses that outright — pass ref so you never
+#     have to rely on the guard catching it.
 gh workflow run manual-publish.yml --repo Alteriom/painlessMesh \
-  -f publish_npm=true -f publish_github=false
+  -f ref=v1.9.21 -f publish_npm=true -f publish_github=false
 
 # 5. Confirm the version actually landed
 npm view @alteriom/painlessmesh version
+```
+
+#### Where NPM_TOKEN actually lives
+
+`NPM_TOKEN` is an **organisation** secret on `Alteriom`, shared by every repo
+that publishes to npm. painlessMesh has **no repository-level copy**, and adding
+one is a trap rather than a tightening:
+
+> A repository secret silently takes precedence over an organisation secret of
+> the same name. The repo then stops seeing org-wide rotations and keeps using
+> its own copy until that copy expires — which is invisible until a release day
+> fails.
+
+Two sibling repos already sit in that state, with repo-level `NPM_TOKEN` copies
+that shadow the org secret (`webhook-client`, `repository-metadata-manager`).
+Rotate the org secret and those two are still broken; delete the repo-level copy
+and they inherit the fresh one. Check before assuming a rotation reached a repo:
+
+```bash
+# Empty output = good (inherits the org secret)
+gh api repos/Alteriom/<repo>/actions/secrets \
+  --jq '.secrets[] | select(.name=="NPM_TOKEN") | "SHADOWED, updated \(.updated_at)"'
 ```
 
 While rotating `NPM_TOKEN`, check `PLATFORMIO_AUTH_TOKEN` too — it expires the
@@ -751,7 +779,9 @@ Monitor your releases:
 ### Required GitHub Secrets
 
 - `GITHUB_TOKEN`: Automatically provided by GitHub Actions
-- `NPM_TOKEN`: Required for NPM publishing (add in repository secrets)
+- `NPM_TOKEN`: Required for NPM publishing. Lives in the **Alteriom
+  organisation** secrets and is inherited — do not add a repository-level copy,
+  which would shadow it (see [Where NPM_TOKEN actually lives](#where-npm_token-actually-lives))
 - `PLATFORMIO_AUTH_TOKEN`: Required for PlatformIO Library Registry publishing
 
 Both `NPM_TOKEN` and `PLATFORMIO_AUTH_TOKEN` are user-minted tokens that

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -64,7 +64,10 @@ npm removed the legacy "Automation" token type in November 2025. A granular
 token without "Bypass 2FA" behaves like the old "Publish" token and lands
 exactly here, so a token minted by muscle memory hits this.
 
-Then update the NPM_TOKEN repository secret and re-run.
+Then update the NPM_TOKEN *organisation* secret and re-run:
+  https://github.com/organizations/Alteriom/settings/secrets/actions
+Do not add a repository-level NPM_TOKEN — it silently shadows the org
+secret, so the next org-wide rotation will not reach this repo.
 
 Longer term: npm is removing direct publish from bypass-2FA tokens
 (targeted January 2027). Migrating to trusted publishing (OIDC) retires
@@ -83,7 +86,10 @@ The NPM_TOKEN secret has expired or been revoked. Mint a replacement at
 Verify it before saving the secret:
   curl -sS -H "Authorization: Bearer <new-token>" https://registry.npmjs.org/-/whoami
 
-Then update the NPM_TOKEN repository secret and re-run.
+Then update the NPM_TOKEN *organisation* secret and re-run:
+  https://github.com/organizations/Alteriom/settings/secrets/actions
+Do not add a repository-level NPM_TOKEN — it silently shadows the org
+secret, so the next org-wide rotation will not reach this repo.
 EOF
     ;;
 *"cannot publish over"* | *"You cannot publish over the previously published versions"*)


### PR DESCRIPTION
Follow-up to #392 / #399 / #400. Those made the npm publish failures *legible*; this makes the recovery path safe to actually run.

## 1. Republishing a missed release would have corrupted the version

`manual-publish.yml` always checked out the default branch. That is fine when publishing is part of a release run, but #381's whole recovery step is "dispatch the manual workflow to publish the version npm missed" — and by then main has moved:

| | |
|---|---|
| npm `latest` | `1.9.20` |
| `package.json` / `library.properties` on main | `1.9.21` |
| main vs tag `v1.9.21` | **231 insertions across 5 library source files** (#393, #395) |

So dispatching the documented recovery command today would have uploaded main's code to npm as `1.9.21`. npm versions are immutable, so that is not fixable afterwards — npm `1.9.21` would permanently disagree with git `v1.9.21` and with the GitHub Release assets, and anyone installing `1.9.21` would silently get the unreleased TCP-retry feature from #395.

- adds a `ref` input (`-f ref=v1.9.21`), honoured by both jobs
- adds a guard that refuses to publish version `X` from any commit that is not tag `vX`, and prints the exact `gh workflow run` command to do it correctly
- guard no-ops when no tag `vX` exists, so first publications still work

## 2. The runbook told operators to create the secret that breaks rotations

`NPM_TOKEN` is an **organisation** secret on `Alteriom`. painlessMesh has no repository-level copy. Every failure message here — and step 3 of the rotation runbook — said to update "the NPM_TOKEN repository secret", which would *create* one.

A repository secret silently takes precedence over an org secret of the same name. The repo then stops seeing org-wide rotations and runs on its own copy until that copy expires, invisibly, until a release day fails.

This is not hypothetical — two sibling repos are already in that state, with repo-level copies that shadow the org secret:

| Repo | repo-level `NPM_TOKEN` last updated |
|---|---|
| `Alteriom/webhook-client` | 2026-03-05 |
| `Alteriom/repository-metadata-manager` | 2026-03-27 |

The org secret was rotated 2026-08-12; **those two repos did not receive it.** Runbook now documents the precedence trap and the one-liner to check for it.

## Verification

Workflow YAML parses and every embedded `run:` script passes `bash -n`. The new guard was executed against this repo's real git history:

| Case | Result |
|---|---|
| version `1.9.21`, HEAD = main (tag exists, differs) | ❌ refuses, exit 1 — *the bug this prevents* |
| version `1.9.21`, HEAD = `v1.9.21` | ✅ passes, exit 0 |
| version `9.9.9`, no such tag | ✅ passes with info, exit 0 |

**Not verified:** no publish was run, so whether the rotated org token is free of the `EOTP` problem from #381 is still unproven — `npm whoami` cannot detect it and only a real publish can. See the issue comment for the operator handoff.

Refs #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)