### PR TITLE
release: v1.10.0 — user-configurable TCP retry parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
             sketch="${example}$(basename "$example").ino"
             if [ -f "$sketch" ]; then
               echo "Building example: $example"
-              arduino-cli compile --fqbn ${{ matrix.fqbn }} "$example"
+              arduino-cli compile --fqbn ${{ matrix.fqbn }} "$example" --config-dir test/ci/
             fi
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
               break
             else
               if [[ "$i" == "3" ]]; then
+                echo "Index update failed after $i attempts."
                 exit 1
               fi
               echo "Attempt $i failed, retrying in 5 seconds..."
@@ -151,6 +152,7 @@ jobs:
               break
             else
               if [[ "$i" == "3" ]]; then
+                echo "Core install for ${{ matrix.core }} failed after $i attempts."
                 exit 1
               fi
               echo "Core install attempt $i failed, retrying in 5 seconds..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,12 @@ jobs:
         include:
           - board: esp32
             fqbn: esp32:esp32:esp32
+            core: esp32:esp32
+            async_lib: AsyncTCP
           - board: esp8266
             fqbn: esp8266:esp8266:generic
+            core: esp8266:esp8266
+            async_lib: ESPAsyncTCP
     
     steps:
       - name: Checkout
@@ -123,26 +127,40 @@ jobs:
         run: |
           arduino-cli config init --config-dir test/ci/
           
-          # Add ESP8266 board manager URL first
-          arduino-cli config add board_manager.additional_urls http://arduino.esp8266.com/stable/package_esp8266com_index.json --config-dir test/ci/
+          # Add ESP8266 board manager URL only when needed
+          if [[ "${{ matrix.board }}" == "esp8266" ]]; then
+            arduino-cli config add board_manager.additional_urls http://arduino.esp8266.com/stable/package_esp8266com_index.json --config-dir test/ci/
+          fi
           
           # Update index with retry logic for transient server errors
           for i in 1 2 3; do
             if arduino-cli core update-index --config-dir test/ci/; then
               break
             else
+              if [[ "$i" == "3" ]]; then
+                exit 1
+              fi
               echo "Attempt $i failed, retrying in 5 seconds..."
               sleep 5
             fi
           done
           
-          # Install both ESP32 and ESP8266 platforms
-          arduino-cli core install esp32:esp32 --config-dir test/ci/
-          arduino-cli core install esp8266:esp8266 --config-dir test/ci/
+          # Install only the selected platform, with retries for transient outages
+          for i in 1 2 3; do
+            if arduino-cli core install ${{ matrix.core }} --config-dir test/ci/; then
+              break
+            else
+              if [[ "$i" == "3" ]]; then
+                exit 1
+              fi
+              echo "Core install attempt $i failed, retrying in 5 seconds..."
+              sleep 5
+            fi
+          done
 
       - name: Install library dependencies
         run: |
-          arduino-cli lib install ArduinoJson TaskScheduler AsyncTCP ESPAsyncTCP
+          arduino-cli lib install ArduinoJson TaskScheduler ${{ matrix.async_lib }}
 
       - name: Install library from source
         run: |
@@ -152,7 +170,8 @@ jobs:
       - name: Compile examples
         run: |
           for example in examples/*/; do
-            if [ -f "${example}*.ino" ]; then
+            sketch="${example}$(basename "$example").ino"
+            if [ -f "$sketch" ]; then
               echo "Building example: $example"
               arduino-cli compile --fqbn ${{ matrix.fqbn }} "$example"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,13 +162,11 @@ jobs:
 
       - name: Install library dependencies
         run: |
-          arduino-cli lib install \
+          arduino-cli --config-dir test/ci/ lib install \
             ArduinoJson \
             TaskScheduler \
             ${{ matrix.async_lib }} \
-            PubSubClient \
-            ESPAsyncWebServer \
-            --config-dir test/ci/
+            PubSubClient
 
       - name: Install library from source
         run: |
@@ -178,6 +176,10 @@ jobs:
       - name: Compile examples
         run: |
           for example in examples/*/; do
+            if [ "$(basename "$example")" = "webServer" ]; then
+              echo "Skipping example with external dependency not available via Arduino Library Manager: $example"
+              continue
+            fi
             sketch="${example}$(basename "$example").ino"
             if [ -f "$sketch" ]; then
               echo "Building example: $example"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,13 @@ jobs:
 
       - name: Install library dependencies
         run: |
-          arduino-cli lib install ArduinoJson TaskScheduler ${{ matrix.async_lib }}
+          arduino-cli lib install \
+            ArduinoJson \
+            TaskScheduler \
+            ${{ matrix.async_lib }} \
+            PubSubClient \
+            ESPAsyncWebServer \
+            --config-dir test/ci/
 
       - name: Install library from source
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-08-12
+
+Feature release making the TCP connect-retry envelope tunable per mesh instance
+(#378), alongside two documentation corrections that retire long-standing claims
+the library never actually implemented (#385) and an example build fix (#360).
+
+**Upgrading is behaviour-neutral.** Every new setting defaults to the value that
+was previously hardcoded, so a sketch that does not call `setTcpRetryConfig()`
+behaves exactly as it did on 1.9.21. Nothing was removed: the deprecated queue
+macros keep their historical values for source compatibility.
+
+> **Note for npm users:** v1.9.21 was never published to npm — the `NPM_TOKEN`
+> used by CI had expired (#381), which failed the npm publish job while the
+> GitHub Release, GitHub Packages, PlatformIO and Arduino channels all succeeded.
+> npm's previous version is therefore **1.9.20**, and upgrading from npm brings
+> in both 1.9.21 and 1.10.0. See the 1.9.21 entry below for what that release
+> contained — it was a crash-fix release, and npm users have been missing it.
+
 ### Added
 
 - **User-configurable TCP retry parameters (#378)** — the five TCP connect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — painlessMesh
 
-C++ mesh networking library for ESP32/ESP8266 (PlatformIO). Alteriom fork of painlessMesh v1.9.21.
+C++ mesh networking library for ESP32/ESP8266 (PlatformIO). Alteriom fork of painlessMesh v1.10.0.
 
 ## Key Directories
 
@@ -44,4 +44,4 @@ pio run -e <env>
 
 ## Version
 
-Current: **v1.9.21**
+Current: **v1.10.0**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-**Version 1.9.21** - Crash fixes: use-after-free in task and TCP connection lifecycle (#373)
+**Version 1.10.0** - Tunable TCP connect-retry behaviour via `setTcpRetryConfig()` (#378)
 
 [![CI/CD Pipeline](https://github.com/Alteriom/painlessMesh/actions/workflows/ci.yml/badge.svg)](https://github.com/Alteriom/painlessMesh/actions/workflows/ci.yml)
 [![Documentation](https://github.com/Alteriom/painlessMesh/actions/workflows/docs.yml/badge.svg)](https://github.com/Alteriom/painlessMesh/actions/workflows/docs.yml)
@@ -560,7 +560,20 @@ These are the message types used by applications built on painlessMesh:
 - **Event Coordination** - Synchronized displays, distributed processing
 - **Bridge Networks** - Connect mesh to WiFi/Internet/MQTT - [📖 Bridge Guide](BRIDGE_TO_INTERNET.md)
 
-## Latest Release: v1.9.21 (August 4, 2026)
+## Latest Release: v1.10.0 (August 12, 2026)
+
+**Tunable TCP Connect-Retry Behaviour (issue #378)**
+
+- The five TCP connect-retry values that were hardcoded in `tcp.hpp` are now tunable per mesh instance via `mesh.setTcpRetryConfig()` / `mesh.getTcpRetryConfig()` (#378, PR #395)
+- Defaults match the previous constants exactly — **no behaviour change unless you call the setter**
+- New `examples/tcpRetryConfig/` with real-time, high-reliability and battery-saver profiles
+- `MessageQueue` documentation corrected: it is a manual buffer, never an auto-flush queue (#385)
+- `MIN_FREE_MEMORY` / `MAX_MESSAGE_QUEUE` deprecated as ignored no-ops, values preserved for source compatibility (#385)
+- Fixed `bridge_failover` example failing to compile on an unqualified `plugin::` type (#360)
+
+> **npm users:** v1.9.21 was never published to npm ([#381](https://github.com/Alteriom/painlessMesh/issues/381) — expired token). npm's previous version is 1.9.20, so upgrading from npm picks up both releases. GitHub, PlatformIO and Arduino were unaffected.
+
+**Previous Release: v1.9.21 (August 4, 2026)**
 
 **Crash Fixes: Task & TCP Connection Lifecycle (issue #373)**
 

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/Alteriom/painlessMesh"
   },
-  "version": "1.9.21",
+  "version": "1.10.0",
   "frameworks": [
     "arduino"
   ],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Alteriom PainlessMesh
-version=1.9.21
+version=1.10.0
 author=Coopdis,Scotty Franzyshen,Edwin van Leeuwen,Germán Martín,Maximilian Schwarz,Doanh Doanh,Alteriom
 maintainer=Alteriom
 sentence=A painless way to setup a mesh with ESP8266 and ESP32 devices with Alteriom extensions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alteriom/painlessmesh",
-  "version": "1.9.21",
+  "version": "1.10.0",
   "description": "painlessMesh is a user-friendly library for creating mesh networks with ESP8266 and ESP32 devices. This Alteriom fork includes additional packages for sensor data (SensorPackage), device commands (CommandPackage), and status monitoring (StatusPackage). It handles routing and network management automatically, so you can focus on your application. The library uses JSON-based messaging and syncs time across all nodes, making it ideal for coordinated behaviour like synchronized light displays or sensor networks reporting to a central node.",
   "keywords": [
     "arduino",

--- a/src/AlteriomPainlessMesh.h
+++ b/src/AlteriomPainlessMesh.h
@@ -29,10 +29,10 @@
 /**
  * @brief AlteriomPainlessMesh library version information
  */
-#define ALTERIOM_PAINLESS_MESH_VERSION "1.9.21"
+#define ALTERIOM_PAINLESS_MESH_VERSION "1.10.0"
 #define ALTERIOM_PAINLESS_MESH_VERSION_MAJOR 1
-#define ALTERIOM_PAINLESS_MESH_VERSION_MINOR 9
-#define ALTERIOM_PAINLESS_MESH_VERSION_PATCH 20
+#define ALTERIOM_PAINLESS_MESH_VERSION_MINOR 10
+#define ALTERIOM_PAINLESS_MESH_VERSION_PATCH 0
 
 /**
  * @brief Library description and usage information

--- a/src/painlessMesh.h
+++ b/src/painlessMesh.h
@@ -5,8 +5,8 @@
  * @file painlessMesh.h
  * @brief Main header file for Alteriom painlessMesh library
  * 
- * @version 1.9.21
- * @date 2025-12-21
+ * @version 1.10.0
+ * @date 2026-08-12
  * 
  * painlessMesh is a user-friendly library for creating mesh networks with 
  * ESP8266 and ESP32 devices. This Alteriom fork includes additional packages 


### PR DESCRIPTION
Bumps main to **1.10.0** and promotes the existing `[Unreleased]` changelog section into a dated release entry.

## Why 1.10.0 and not 1.9.22

`main` has been sitting at version `1.9.21` while carrying content that is not 1.9.21. Since the tag, #395 landed **a feature** — per-instance TCP connect-retry configuration — so semver calls for a minor bump:

| Since `v1.9.21` | |
|---|---|
| #395 (#378) | **feat** — `setTcpRetryConfig()` / `getTcpRetryConfig()`, new `TcpRetryConfig` struct, new example |
| #393 (#385) | docs — `MessageQueue` documented as a manual buffer; queue macros deprecated as no-ops |
| #380 (#360) | fix — `bridge_failover` example failed to compile |
| #392/#399/#400 | CI/release plumbing only, no library change |

## What changed

All seven version-bearing files the release guide lists, via `./scripts/bump-version.sh minor` plus the four it does not cover:

`library.properties` · `library.json` · `package.json` · `src/painlessMesh.h` · `src/AlteriomPainlessMesh.h` · `README.md` · `CHANGELOG.md` (+ `CLAUDE.md`)

Also fixes `ALTERIOM_PAINLESS_MESH_VERSION_PATCH`, which was **left at `20`** during the 1.9.21 release while the version string moved to `1.9.21` — anything reading the numeric macros has been getting the wrong patch number since August 4.

## Release notes

`release.yml` extracts the `## [1.10.0]` section verbatim as the GitHub Release body. I ran that exact `awk` against this changelog — it yields 74 lines covering Added / Changed / Deprecated / Fixed, with an upgrade-impact summary at the top.

The entry leads with **upgrading is behaviour-neutral**: every new setting defaults to the previously hardcoded value, so a sketch that never calls `setTcpRetryConfig()` behaves exactly as on 1.9.21, and the deprecated macros keep their historical values.

It also carries a note for npm users, since this is the release that closes out #381:

> v1.9.21 was never published to npm (expired `NPM_TOKEN`). npm's previous version is **1.9.20**, so upgrading from npm brings in both 1.9.21 and 1.10.0.

## Verification

- `./scripts/validate-release.sh` — version consistency ✅, changelog entry found ✅, tag `v1.10.0` free ✅, dependencies ✅, essential files ✅. Its build step fails locally on `cmake: command not found` (absent from this container); CI's gcc/clang/asan jobs cover it.
- Release-notes extraction verified with `release.yml`'s own awk expression.
- Grepped the tree: no stale `1.9.21` outside changelog history and release-guide prose.

## ⚠️ Merging this publishes

Merging to `main` triggers **Automated Release**: tag `v1.10.0`, GitHub Release, npm + GitHub Packages publish, PlatformIO publish, wiki sync. Two things worth knowing before you click:

1. **This is the first publish since the token rotation**, so it is also the live test of whether the new `NPM_TOKEN` can actually publish. `npm whoami` passes for both bypass-2FA and non-bypass granular tokens, so only a real publish proves it. If it fails with `EOTP`, the token needs re-minting with **Bypass 2FA** — #400's error handler explains this at the failure point.
2. **#383 proposes a competing `2.0.0`** (per-message ACK API, open since Aug 4, 8 days stale). This PR does not touch it; 2.0.0 still sorts above 1.10.0, so #383 stays valid but will need a rebase and a changelog reconcile.

Refs #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)